### PR TITLE
 tests: overwrite previous aggregations

### DIFF
--- a/examples/app.py
+++ b/examples/app.py
@@ -36,7 +36,7 @@ from __future__ import absolute_import, print_function
 
 import os.path
 import random
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 
 from flask import Flask
 from invenio_queues import InvenioQueues
@@ -77,7 +77,9 @@ app.register_blueprint(blueprint)
 def fixtures():
     """Command for working with test data."""
 
-def publish_filedownload(nb_events, user_id, filename, file_id, bucket_id, date):
+
+def publish_filedownload(nb_events, user_id, filename,
+                         file_id, bucket_id, date):
     current_stats.publish('file-download', [dict(
         # When:
         timestamp=date.isoformat(),
@@ -89,6 +91,7 @@ def publish_filedownload(nb_events, user_id, filename, file_id, bucket_id, date)
         user_id=str(user_id)
     )] * nb_events)
 
+
 @fixtures.command()
 def events():
     # Create events
@@ -98,12 +101,13 @@ def events():
     random.seed(42)
     for _ in range(nb_days):
         publish_filedownload(random.randrange(1, max_events),
-                            1, 'test.txt', 10, 20, day)
+                             1, 'test.txt', 10, 20, day)
         day = day + timedelta(days=1)
 
     process_events(['file-download'])
     # flush elasticsearch indices so that the events become searchable
     current_search_client.indices.flush(index='*')
+
 
 @fixtures.command()
 def aggregations():

--- a/invenio_stats/errors.py
+++ b/invenio_stats/errors.py
@@ -28,10 +28,10 @@ from __future__ import absolute_import, print_function
 
 from invenio_rest.errors import RESTException
 
-
 ##
 #  Events errors
 ##
+
 
 class DuplicateEventError(Exception):
     """Error raised when a duplicate event is detected."""

--- a/tests/test_invenio_stats.py
+++ b/tests/test_invenio_stats.py
@@ -26,13 +26,15 @@
 
 from __future__ import absolute_import, print_function
 
+import datetime
 import uuid
 
 import pytest
 from elasticsearch_dsl import Search
 from flask import Flask
 from invenio_queues.proxies import current_queues
-from invenio_search import current_search_client
+from invenio_search import current_search, current_search_client
+from mock import patch
 
 from invenio_stats import InvenioStats
 from invenio_stats.proxies import current_stats
@@ -77,10 +79,12 @@ def test_publish_and_consume_events(app, event_entrypoints):
     assert list(current_stats.consume(event_type)) == events
 
 
+@pytest.mark.parametrize('queued_events',
+                         [[datetime.datetime.utcnow().isoformat()]],
+                         indirect=['queued_events'])
 def test_batch_events(app, event_entrypoints, objects,
                       queued_events, sequential_ids):
     """Test processing of multiple events and checking aggregation counts."""
-
     process_events(['file-download'])
     aggregate_events.delay(['file-download-agg'])
     current_search_client.indices.flush(index='*')
@@ -100,5 +104,83 @@ def test_batch_events(app, event_entrypoints, objects,
 
 
 def test_wrong_intervals(app):
+    """Test wrong interval error."""
     with pytest.raises(ValueError):
         StatAggregator(current_search_client, 'test', 'test', 'month', 'day')
+
+
+def test_overwriting_aggregations(app, mock_user_ctx, sequential_ids):
+    """1. Create sample file download event and process it.
+       2. Run aggregator and write count, in aggregation index.
+       3. Create new events and repeat procedure to assert that the
+          results within the interval of the previous events
+          overwrite the aggregation,
+          by checking that the document version has increased."""
+    for t in current_search.put_templates(ignore=[400]):
+        pass
+
+    event_type = 'file-download'
+    events = [dict(timestamp=datetime.datetime.strptime('2017-06-01',
+                                                        '%Y-%m-%d').
+                   isoformat(),
+                   # What:
+                   bucket_id=str(sequential_ids[0]),
+                   file_id=str(sequential_ids[0]),
+                   filename='test.pdf',
+                   visitor_id=100),
+              dict(timestamp=datetime.date.today().strftime('%Y-%m-%d'),
+                   # What:
+                   bucket_id=str(sequential_ids[0]),
+                   file_id=str(sequential_ids[0]),
+                   filename='test.pdf',
+                   visitor_id=100)]
+    current_queues.declare()
+    current_stats.publish(event_type, events)
+    process_events(['file-download'])
+    current_search_client.indices.flush(index='*')
+    aggregate_events(['file-download-agg'])
+
+    res = current_search_client.search(index='stats-file-download',
+                                       version=True)
+    for hit in res['hits']['hits']:
+        if 'file_id' in hit['_source'].keys():
+            assert hit['_version'] == 1
+
+    new_events = [dict(timestamp=datetime.date.today().strftime('%Y-%m-%d'),
+                       # What:
+                       bucket_id=str(sequential_ids[0]),
+                       file_id=str(sequential_ids[0]),
+                       filename='test.pdf',
+                       visitor_id=100),
+                  dict(timestamp=datetime.datetime.strptime('3000-01-01',
+                                                            '%Y-%m-%d').
+                       isoformat(),
+                       # What:
+                       bucket_id=str(sequential_ids[0]),
+                       file_id=str(sequential_ids[0]),
+                       filename='test.pdf',
+                       visitor_id=100)]
+    current_stats.publish(event_type, new_events)
+    process_events(['file-download'])
+    current_search_client.indices.flush(index='*')
+
+    class NewDate(datetime.datetime):
+        @classmethod
+        def utcnow(cls):
+            return cls(3000, 2, 1)
+    datetime.datetime = NewDate
+
+    with patch('datetime.datetime', NewDate):
+        aggregate_events(['file-download-agg'])
+
+    res = current_search_client.search(index='stats-file-download',
+                                       version=True)
+    for hit in res['hits']['hits']:
+        if 'file_id' in hit['_source'].keys() and \
+                hit['_index'] == 'stats-file-download-2017-07':
+            assert hit['_version'] == 2
+        elif 'file_id' in hit['_source'].keys():
+            assert hit['_version'] == 1
+
+    current_search_client.indices.delete(index='events-stats-file-download')
+    current_search_client.indices.delete(index='stats-file-download')


### PR DESCRIPTION
* ADDS test adding new events within interval, to assert 
   that the aggregation will overwrite previous results.

* ADDS fixtures in conftest for creating events with different dates.
   (Hardcoded to 10k events per given day for now). 