### PR TITLE
global: addition of event id

### DIFF
--- a/invenio_stats/contrib/event_builders.py
+++ b/invenio_stats/contrib/event_builders.py
@@ -36,7 +36,8 @@ def file_download_event_builder(event, sender_app, obj=None, **kwargs):
     """Build a file-download event."""
     event.update(dict(
         # When:
-        timestamp=datetime.datetime.utcnow().isoformat(),
+        timestamp=datetime.datetime.utcnow().\
+        replace(microsecond=0).isoformat(),
         # What:
         bucket_id=str(obj.bucket_id),
         file_id=str(obj.file_id),

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -26,11 +26,7 @@
 
 from __future__ import absolute_import, print_function
 
-import datetime
-import uuid
-
-from elasticsearch_dsl import Search
-from invenio_search import current_search, current_search_client
+from datetime import datetime
 
 from invenio_stats import current_stats
 from invenio_stats.tasks import aggregate_events, process_events
@@ -38,7 +34,9 @@ from invenio_stats.tasks import aggregate_events, process_events
 
 def test_process_events(app, es, event_queues):
     """Test process event."""
-    current_stats.publish('file-download', [dict(data='val')])
+    current_stats.publish('file-download',
+                          [dict(timestamp='2017-01-01T00:00:00',
+                                data='val')])
     process_events.delay(['file-download'])
     # FIXME: no need to publish events. We should just mock "consume" and test
     # that the events are properly received and processed.


### PR DESCRIPTION
* ADD custom event _id field, which includes the timestamp,
  object id and visitor id so that events occuring within a
  specified time window are only counted once.

Signed-off-by: Dinos Kousidis <konstantinos.kousidis@cern.ch>