### PR TITLE
global: filtering of events from deposits

### DIFF
--- a/invenio_stats/contrib/registrations.py
+++ b/invenio_stats/contrib/registrations.py
@@ -27,7 +27,8 @@ from invenio_search import current_search_client
 
 from invenio_stats.aggregations import StatAggregator
 from invenio_stats.contrib.event_builders import build_file_unique_id
-from invenio_stats.processors import EventsIndexer, anonymize_user, flag_robots
+from invenio_stats.processors import EventsIndexer, anonymize_user, \
+    flag_robots, skip_deposit
 from invenio_stats.queries import ESDateHistogramQuery, ESTermsQuery
 
 
@@ -37,11 +38,12 @@ def register_events():
                  templates='contrib/file-download',
                  processor_class=EventsIndexer,
                  processor_config=dict(
-                    preprocessors=[
-                        flag_robots,
-                        anonymize_user,
-                        build_file_unique_id
-                    ]
+                     preprocessors=[
+                         skip_deposit,
+                         flag_robots,
+                         anonymize_user,
+                         build_file_unique_id
+                     ]
                  )),
             dict(event_type='record-view',
                  templates='contrib/record-view',


### PR DESCRIPTION
* ADD preprocessor to check if an event is coming from a deposit
  page and skip.

Signed-off-by: Dinos Kousidis <konstantinos.kousidis@cern.ch>