### PR TITLE
processors: hash _id field

### DIFF
--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -36,6 +36,8 @@ def test_process_events(app, es, event_queues):
     """Test process event."""
     current_stats.publish('file-download',
                           [dict(timestamp='2017-01-01T00:00:00',
+                                visitor_id='testuser1',
+                                unique_id='2017-01-01T00:00:00-hash',
                                 data='val')])
     process_events.delay(['file-download'])
     # FIXME: no need to publish events. We should just mock "consume" and test


### PR DESCRIPTION
* ADD hashing of visitor id and unique id of an event to
  shorten its _id field
 
Signed-off-by: Dinos Kousidis <konstantinos.kousidis@cern.ch>