### PR TITLE
global: fix elasticsearch 2.2 timestamp conflict

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,8 @@ env:
   - REQUIREMENTS=lowest ES_URL="https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.4.5/elasticsearch-2.4.5.tar.gz" BROKER_URL=amqp://localhost:5672//
   - REQUIREMENTS=release ES_URL="https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.4.5/elasticsearch-2.4.5.tar.gz" BROKER_URL=redis://localhost:6379/0
   - REQUIREMENTS=release ES_URL="https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.4.5/elasticsearch-2.4.5.tar.gz" BROKER_URL=amqp://localhost:5672// DEPLOY=true
+  # Test with elasticsearch 2.2
+  - REQUIREMENTS=release ES_URL="https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.2.2/elasticsearch-2.2.2.tar.gz" BROKER_URL=amqp://localhost:5672//
   - REQUIREMENTS=devel ES_HOST=127.0.0.1 ES_URL="https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.4.5/elasticsearch-2.4.5.tar.gz" BROKER_URL=redis://localhost:6379/0
   - REQUIREMENTS=devel ES_HOST=127.0.0.1 ES_URL="https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.4.5/elasticsearch-2.4.5.tar.gz" BROKER_URL=amqp://localhost:5672//
 

--- a/invenio_stats/contrib/aggregations/aggr-file-download/aggr-file-download-v1.json
+++ b/invenio_stats/contrib/aggregations/aggr-file-download/aggr-file-download-v1.json
@@ -6,6 +6,19 @@
     }
   },
   "mappings": {
+    "_default_": {
+      "dynamic_templates": [
+        {
+          "date_fields": {
+            "match_mapping_type": "date",
+            "mapping": {
+              "type": "date",
+              "format": "date_optional_time"
+            }
+          }
+        }
+      ]
+    },
     "file-download-aggregation": {
       "_source": {
         "enabled": true

--- a/invenio_stats/contrib/file-download/file-download-v1.json
+++ b/invenio_stats/contrib/file-download/file-download-v1.json
@@ -6,6 +6,19 @@
     }
   },
   "mappings": {
+    "_default_": {
+      "dynamic_templates": [
+        {
+          "date_fields": {
+            "match_mapping_type": "date",
+            "mapping": {
+              "type": "date",
+              "format": "strict_date_hour_minute_second"
+            }
+          }
+        }
+      ]
+    },
     "file-download": {
       "_source": {
         "enabled": false

--- a/tests/test_aggregations.py
+++ b/tests/test_aggregations.py
@@ -25,6 +25,7 @@
 """Aggregation tests."""
 
 import datetime
+import time
 
 import pytest
 from conftest import _create_file_download_event
@@ -140,6 +141,8 @@ def test_aggregation_without_events(app, es_with_templates):
     # have been indexed but are not yet searchable (before index refresh).
     Index('events-stats-file-download-2017',
           using=current_search_client).create()
+    # Wait for the index to be available
+    time.sleep(1)
     # Aggregate events
     StatAggregator(event='file-download',
                    aggregation_field='file_id',


### PR DESCRIPTION
* Fixes a bug appearing with elasticsearch 2.2 (closes #39).

Signed-off-by: Nicolas Harraudeau <nicolas.harraudeau@cern.ch>