### PR TITLE
receivers: specify app as signal sender

### DIFF
--- a/invenio_stats/processors.py
+++ b/invenio_stats/processors.py
@@ -34,11 +34,24 @@ import arrow
 import elasticsearch
 from dateutil import parser
 from flask import current_app
+from invenio_db import db
+from invenio_files_rest.models import FileInstance
 from invenio_search import current_search_client
 from pytz import utc
 from robot_detection import is_robot
 
 from .utils import get_geoip, obj_or_import_string
+
+
+def include_size(doc):
+    """Add file size to an event."""
+    file_obj = db.session.query(FileInstance).filter(
+        FileInstance.id == doc.get('file_id')
+    )
+    size = file_obj.size if file_obj else None
+    doc.update(dict(
+        size=size
+    ))
 
 
 def anonymize_user(doc):

--- a/invenio_stats/receivers.py
+++ b/invenio_stats/receivers.py
@@ -62,4 +62,6 @@ def register_receivers(app, config):
         ]
 
         signal = obj_or_import_string(event_config['signal'])
-        signal.connect(EventEmmiter(event_name, event_builders), weak=False)
+        signal.connect(
+            EventEmmiter(event_name, event_builders), sender=app, weak=False
+        )

--- a/invenio_stats/receivers.py
+++ b/invenio_stats/receivers.py
@@ -34,6 +34,7 @@ class EventEmmiter(object):
     """Receive a signal and send an event."""
 
     def __init__(self, name, builders):
+        """Contructor."""
         self.name = name
         self.builders = builders
 
@@ -48,6 +49,7 @@ class EventEmmiter(object):
                 current_stats.publish(self.name, [event])
 
     def __repr__(self):
+        """Repr."""
         return '<EventEmmiter: {} ({})>'.format(self.name, self.origin)
 
 

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ tests_require = [
     'elasticsearch-dsl<5,>=2.0.0',
     'invenio-db>=1.0.0b5',
     'invenio-accounts>=1.0.0b9',
+    'invenio-files-rest>=1.0.0a23',
     'invenio-oauth2server>=1.0.0b1',
     'invenio-records>=1.0.0b2',
     'isort>=4.2.15',


### PR DESCRIPTION
* Specifies the Flask application as the signal sender to avoid double
  publishing of events. (closes #50)