### PR TITLE
templates: fix ES v5 and v6 support

### DIFF
--- a/invenio_stats/contrib/aggregations/aggr_file_download/v2/aggr-file-download-v1.json
+++ b/invenio_stats/contrib/aggregations/aggr_file_download/v2/aggr-file-download-v1.json
@@ -33,16 +33,13 @@
           "format": "date_optional_time"
         },
         "count": {
-          "type": "integer",
-          "index": "not_analyzed"
+          "type": "integer"
         },
         "unique_count": {
-          "type": "integer",
-          "index": "not_analyzed"
+          "type": "integer"
         },
         "volume": {
-          "type": "double",
-          "index": "not_analyzed"
+          "type": "double"
         },
         "file_id": {
           "type": "string",

--- a/invenio_stats/contrib/aggregations/aggr_file_download/v5/aggr-file-download-v1.json
+++ b/invenio_stats/contrib/aggregations/aggr_file_download/v5/aggr-file-download-v1.json
@@ -33,24 +33,19 @@
           "format": "date_optional_time"
         },
         "count": {
-          "type": "integer",
-          "index": "not_analyzed"
+          "type": "integer"
         },
         "file_id": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "text"
         },
         "file_key": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "text"
         },
         "bucket_id": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "text"
         },
         "collection": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "text"
         }
       }
     },

--- a/invenio_stats/contrib/aggregations/aggr_file_download/v6/aggr-file-download-v1.json
+++ b/invenio_stats/contrib/aggregations/aggr_file_download/v6/aggr-file-download-v1.json
@@ -1,5 +1,5 @@
 {
-  "template": "stats-file-download-*",
+  "index_patterns": ["stats-file-download-*"],
   "settings": {
     "index.mapper.dynamic": false,
     "index": {
@@ -33,24 +33,19 @@
           "format": "date_optional_time"
         },
         "count": {
-          "type": "integer",
-          "index": "not_analyzed"
+          "type": "integer"
         },
         "file_id": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "text"
         },
         "file_key": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "text"
         },
         "bucket_id": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "text"
         },
         "collection": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "text"
         }
       }
     },

--- a/invenio_stats/contrib/aggregations/aggr_record_view/v2/aggr-record-view-v1.json
+++ b/invenio_stats/contrib/aggregations/aggr_record_view/v2/aggr-record-view-v1.json
@@ -20,12 +20,10 @@
           "format": "date_optional_time"
         },
         "count": {
-          "type": "integer",
-          "index": "not_analyzed"
+          "type": "integer"
         },
         "unique_count": {
-          "type": "integer",
-          "index": "not_analyzed"
+          "type": "integer"
         },
         "record_id": {
           "type": "string",

--- a/invenio_stats/contrib/aggregations/aggr_record_view/v5/aggr-record-view-v1.json
+++ b/invenio_stats/contrib/aggregations/aggr_record_view/v5/aggr-record-view-v1.json
@@ -20,16 +20,13 @@
           "format": "date_optional_time"
         },
         "count": {
-          "type": "integer",
-          "index": "not_analyzed"
+          "type": "integer"
         },
         "record_id": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "text"
         },
         "collection": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "text"
         }
       }
     },

--- a/invenio_stats/contrib/aggregations/aggr_record_view/v6/aggr-record-view-v1.json
+++ b/invenio_stats/contrib/aggregations/aggr_record_view/v6/aggr-record-view-v1.json
@@ -1,5 +1,5 @@
 {
-  "template": "stats-record-view-*",
+  "index_patterns": ["stats-record-view-*"],
   "settings": {
     "index.mapper.dynamic": false,
     "index": {
@@ -24,12 +24,10 @@
           "index": "not_analyzed"
         },
         "record_id": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "text"
         },
         "collection": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "text"
         }
       }
     },

--- a/invenio_stats/contrib/file_download/v2/file-download-v1.json
+++ b/invenio_stats/contrib/file_download/v2/file-download-v1.json
@@ -69,12 +69,10 @@
           "index": "not_analyzed"
         },
         "is_robot": {
-          "type": "boolean",
-          "index": "not_analyzed"
+          "type": "boolean"
         },
         "size": {
-          "type": "double",
-          "index": "not_analyzed"
+          "type": "double"
         }
       }
     }

--- a/invenio_stats/contrib/file_download/v5/file-download-v1.json
+++ b/invenio_stats/contrib/file_download/v5/file-download-v1.json
@@ -33,32 +33,25 @@
           "format": "strict_date_hour_minute_second"
         },
         "bucket_id": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "text"
         },
         "file_id": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "text"
         },
         "file_key": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "text"
         },
         "unique_id": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "text"
         },
         "country": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "text"
         },
         "visitor_id": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "text"
         },
         "collection": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "text"
         }
       }
     }

--- a/invenio_stats/contrib/file_download/v6/file-download-v1.json
+++ b/invenio_stats/contrib/file_download/v6/file-download-v1.json
@@ -1,5 +1,5 @@
 {
-  "template": "events-stats-file-download-*",
+  "index_patterns": ["events-stats-file-download-*"],
   "settings": {
     "index.mapper.dynamic": false,
     "index": {
@@ -33,32 +33,25 @@
           "format": "strict_date_hour_minute_second"
         },
         "bucket_id": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "text"
         },
         "file_id": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "text"
         },
         "file_key": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "text"
         },
         "unique_id": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "text"
         },
         "country": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "text"
         },
         "visitor_id": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "text"
         },
         "collection": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "text"
         }
       }
     }

--- a/invenio_stats/contrib/record_view/v2/record-view-v1.json
+++ b/invenio_stats/contrib/record_view/v2/record-view-v1.json
@@ -52,8 +52,7 @@
           "index": "not_analyzed"
         },
         "is_robot": {
-          "type": "boolean",
-          "index": "not_analyzed"
+          "type": "boolean"
         }
       }
     }

--- a/invenio_stats/contrib/record_view/v5/record-view-v1.json
+++ b/invenio_stats/contrib/record_view/v5/record-view-v1.json
@@ -20,28 +20,22 @@
           "format": "strict_date_hour_minute_second"
         },
         "record_id": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "text"
         },
         "pid_type": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "text"
         },
         "pid_value": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "text"
         },
         "labels": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "text"
         },
         "country": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "text"
         },
         "visitor_id": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "text"
         }
       }
     }

--- a/invenio_stats/contrib/record_view/v6/record-view-v1.json
+++ b/invenio_stats/contrib/record_view/v6/record-view-v1.json
@@ -1,5 +1,5 @@
 {
-  "template": "events-stats-record-view-*",
+  "index_patterns": ["events-stats-record-view-*"],
   "settings": {
     "index.mapper.dynamic": false,
     "index": {
@@ -20,28 +20,22 @@
           "format": "strict_date_hour_minute_second"
         },
         "record_id": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "text"
         },
         "pid_type": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "text"
         },
         "pid_value": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "text"
         },
         "labels": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "text"
         },
         "country": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "text"
         },
         "visitor_id": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "text"
         }
       }
     }


### PR DESCRIPTION
To be tested with real data on ES 5 and 6, I have just tested template creation.

In ES 6, the keyword "template" has been replaced by "index_patterns".