### PR TITLE
ext: add elasticsearch prefix support

### DIFF
--- a/examples/app.py
+++ b/examples/app.py
@@ -41,13 +41,35 @@ Request a histogram of the number of downloads for a file:
 
 .. code-block:: console
 
-$ curl -XPOST localhost:5000/stats -H "Content-Type: application/json" -d '{"mystat": {"stat": "bucket-file-download-histogram", "params": {"start_date":"2016-12-18", "end_date":"2016-12-19", "interval": "day", "bucket_id": 20, "file_key": "file1.txt"}}}'
+    $ curl -XPOST localhost:5000/stats -H "Content-Type: application/json"
+    -d '{
+        "mystat":{
+            "stat": "bucket-file-download-histogram",
+            "params": {
+                "start_date":"2016-12-18",
+                "end_date":"2016-12-19",
+                "interval": "day",
+                "bucket_id": 20,
+                "file_key": "file1.txt"
+            }
+        }
+    }'
 
 Request a histogram of the number of downloads for a file:
 
 .. code-block:: console
 
-    $ curl -v -XPOST localhost:5000/stats -H "Content-Type: application/json" -d '{"mystat": {"stat": "bucket-file-download-total", "params": {"start_date":"2016-12-18", "end_date":"2016-12-19", "bucket_id": 20}}}'
+    $ curl -v -XPOST localhost:5000/stats -H "Content-Type: application/json"
+    -d '{
+        "mystat": {
+            "stat": "bucket-file-download-total",
+            "params": {
+                "start_date":"2016-12-18",
+                "end_date":"2016-12-19",
+                "bucket_id": 20
+            }
+        }
+    }'
 
 To remove the example application data run:
 

--- a/invenio_stats/aggregations.py
+++ b/invenio_stats/aggregations.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2017-2018 CERN.
+# Copyright (C) 2017-2019 CERN.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -18,6 +18,7 @@ from dateutil import parser
 from elasticsearch.helpers import bulk
 from elasticsearch_dsl import Index, Search
 from invenio_search import current_search_client
+from invenio_search.utils import prefix_index
 
 
 def filter_robots(query):
@@ -86,7 +87,8 @@ class StatAggregator(object):
         self.name = name
         self.client = client or current_search_client
         self.event = event
-        self.aggregation_alias = 'stats-{}'.format(self.event)
+        aggregation_alias = 'stats-{}'.format(self.event)
+        self.aggregation_alias = prefix_index(aggregation_alias)
         self.aggregation_field = aggregation_field
         self.metric_aggregation_fields = metric_aggregation_fields or {}
         self.allowed_metrics = {
@@ -116,7 +118,8 @@ class StatAggregator(object):
         self.index_name_suffix = self.supported_intervals[index_interval]
         self.doc_id_suffix = self.supported_intervals[aggregation_interval]
         self.batch_size = batch_size
-        self.event_index = 'events-stats-{}'.format(self.event)
+        event_index = 'events-stats-{}'.format(self.event)
+        self.event_index = prefix_index(event_index)
 
     @property
     def bookmark_doc_type(self):
@@ -257,6 +260,7 @@ class StatAggregator(object):
                              format(self.event,
                                     interval_date.strftime(
                                         self.index_name_suffix))
+                index_name = prefix_index(index_name)
                 self.indices.add(index_name)
                 yield dict(_id='{0}-{1}'.
                            format(aggregation['key'],

--- a/invenio_stats/contrib/aggregations/aggr_file_download/v2/aggr-file-download-v1.json
+++ b/invenio_stats/contrib/aggregations/aggr_file_download/v2/aggr-file-download-v1.json
@@ -1,5 +1,5 @@
 {
-  "template": "stats-file-download-*",
+  "template": "__SEARCH_INDEX_PREFIX__stats-file-download-*",
   "settings": {
     "index.mapper.dynamic": false,
     "index": {
@@ -73,6 +73,6 @@
     }
   },
   "aliases": {
-    "stats-file-download": {}
+    "__SEARCH_INDEX_PREFIX__stats-file-download": {}
   }
 }

--- a/invenio_stats/contrib/aggregations/aggr_file_download/v5/aggr-file-download-v1.json
+++ b/invenio_stats/contrib/aggregations/aggr_file_download/v5/aggr-file-download-v1.json
@@ -1,5 +1,5 @@
 {
-  "template": "stats-file-download-*",
+  "template": "__SEARCH_INDEX_PREFIX__stats-file-download-*",
   "settings": {
     "index.mapper.dynamic": false,
     "index": {
@@ -65,6 +65,6 @@
     }
   },
   "aliases": {
-    "stats-file-download": {}
+    "__SEARCH_INDEX_PREFIX__stats-file-download": {}
   }
 }

--- a/invenio_stats/contrib/aggregations/aggr_file_download/v6/aggr-file-download-v1.json
+++ b/invenio_stats/contrib/aggregations/aggr_file_download/v6/aggr-file-download-v1.json
@@ -1,5 +1,5 @@
 {
-  "template": "stats-file-download-*",
+  "template": "__SEARCH_INDEX_PREFIX__stats-file-download-*",
   "settings": {
     "index.mapper.dynamic": false,
     "index": {
@@ -65,6 +65,6 @@
     }
   },
   "aliases": {
-    "stats-file-download": {}
+    "__SEARCH_INDEX_PREFIX__stats-file-download": {}
   }
 }

--- a/invenio_stats/contrib/aggregations/aggr_record_view/v2/aggr-record-view-v1.json
+++ b/invenio_stats/contrib/aggregations/aggr_record_view/v2/aggr-record-view-v1.json
@@ -1,5 +1,5 @@
 {
-  "template": "stats-record-view-*",
+  "template": "__SEARCH_INDEX_PREFIX__stats-record-view-*",
   "settings": {
     "index.mapper.dynamic": false,
     "index": {
@@ -48,6 +48,6 @@
     }
   },
   "aliases": {
-    "stats-record-view": {}
+    "__SEARCH_INDEX_PREFIX__stats-record-view": {}
   }
 }

--- a/invenio_stats/contrib/aggregations/aggr_record_view/v5/aggr-record-view-v1.json
+++ b/invenio_stats/contrib/aggregations/aggr_record_view/v5/aggr-record-view-v1.json
@@ -1,5 +1,5 @@
 {
-  "template": "stats-record-view-*",
+  "template": "__SEARCH_INDEX_PREFIX__stats-record-view-*",
   "settings": {
     "index.mapper.dynamic": false,
     "index": {
@@ -44,6 +44,6 @@
     }
   },
   "aliases": {
-    "stats-record-view": {}
+    "__SEARCH_INDEX_PREFIX__stats-record-view": {}
   }
 }

--- a/invenio_stats/contrib/aggregations/aggr_record_view/v6/aggr-record-view-v1.json
+++ b/invenio_stats/contrib/aggregations/aggr_record_view/v6/aggr-record-view-v1.json
@@ -1,5 +1,5 @@
 {
-  "template": "stats-record-view-*",
+  "template": "__SEARCH_INDEX_PREFIX__stats-record-view-*",
   "settings": {
     "index.mapper.dynamic": false,
     "index": {
@@ -44,6 +44,6 @@
     }
   },
   "aliases": {
-    "stats-record-view": {}
+    "__SEARCH_INDEX_PREFIX__stats-record-view": {}
   }
 }

--- a/invenio_stats/contrib/file_download/v2/file-download-v1.json
+++ b/invenio_stats/contrib/file_download/v2/file-download-v1.json
@@ -1,5 +1,5 @@
 {
-  "template": "events-stats-file-download-*",
+  "template": "__SEARCH_INDEX_PREFIX__events-stats-file-download-*",
   "settings": {
     "index.mapper.dynamic": false,
     "index": {
@@ -80,6 +80,6 @@
     }
   },
   "aliases": {
-    "events-stats-file-download": {}
+    "__SEARCH_INDEX_PREFIX__events-stats-file-download": {}
   }
 }

--- a/invenio_stats/contrib/file_download/v5/file-download-v1.json
+++ b/invenio_stats/contrib/file_download/v5/file-download-v1.json
@@ -1,5 +1,5 @@
 {
-  "template": "events-stats-file-download-*",
+  "template": "__SEARCH_INDEX_PREFIX__events-stats-file-download-*",
   "settings": {
     "index.mapper.dynamic": false,
     "index": {
@@ -64,6 +64,6 @@
     }
   },
   "aliases": {
-    "events-stats-file-download": {}
+    "__SEARCH_INDEX_PREFIX__events-stats-file-download": {}
   }
 }

--- a/invenio_stats/contrib/file_download/v6/file-download-v1.json
+++ b/invenio_stats/contrib/file_download/v6/file-download-v1.json
@@ -1,5 +1,5 @@
 {
-  "template": "events-stats-file-download-*",
+  "template": "__SEARCH_INDEX_PREFIX__events-stats-file-download-*",
   "settings": {
     "index.mapper.dynamic": false,
     "index": {
@@ -64,6 +64,6 @@
     }
   },
   "aliases": {
-    "events-stats-file-download": {}
+    "__SEARCH_INDEX_PREFIX__events-stats-file-download": {}
   }
 }

--- a/invenio_stats/contrib/record_view/v2/record-view-v1.json
+++ b/invenio_stats/contrib/record_view/v2/record-view-v1.json
@@ -1,5 +1,5 @@
 {
-  "template": "events-stats-record-view-*",
+  "template": "__SEARCH_INDEX_PREFIX__events-stats-record-view-*",
   "settings": {
     "index.mapper.dynamic": false,
     "index": {
@@ -59,6 +59,6 @@
     }
   },
   "aliases": {
-    "events-stats-record-view": {}
+    "__SEARCH_INDEX_PREFIX__events-stats-record-view": {}
   }
 }

--- a/invenio_stats/contrib/record_view/v5/record-view-v1.json
+++ b/invenio_stats/contrib/record_view/v5/record-view-v1.json
@@ -1,5 +1,5 @@
 {
-  "template": "events-stats-record-view-*",
+  "template": "__SEARCH_INDEX_PREFIX__events-stats-record-view-*",
   "settings": {
     "index.mapper.dynamic": false,
     "index": {
@@ -47,6 +47,6 @@
     }
   },
   "aliases": {
-    "events-stats-record-view": {}
+    "__SEARCH_INDEX_PREFIX__events-stats-record-view": {}
   }
 }

--- a/invenio_stats/contrib/record_view/v6/record-view-v1.json
+++ b/invenio_stats/contrib/record_view/v6/record-view-v1.json
@@ -1,5 +1,5 @@
 {
-  "template": "events-stats-record-view-*",
+  "template": "__SEARCH_INDEX_PREFIX__events-stats-record-view-*",
   "settings": {
     "index.mapper.dynamic": false,
     "index": {
@@ -47,6 +47,6 @@
     }
   },
   "aliases": {
-    "events-stats-record-view": {}
+    "__SEARCH_INDEX_PREFIX__events-stats-record-view": {}
   }
 }

--- a/invenio_stats/ext.py
+++ b/invenio_stats/ext.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2016-2018 CERN.
+# Copyright (C) 2016-2019 CERN.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -13,6 +13,7 @@ from __future__ import absolute_import, print_function
 from collections import namedtuple
 
 from invenio_queues.proxies import current_queues
+from invenio_search.utils import prefix_index
 from pkg_resources import iter_entry_points
 from werkzeug.utils import cached_property
 
@@ -177,6 +178,11 @@ class _InvenioStatsState(object):
                 ),
                 permission_factory=cfg.get('permission_factory')
             )
+
+            index = prefix_index(
+                result[cfg['query_name']].query_config['index'])
+            result[cfg['query_name']].query_config['index'] = index
+
         return result
 
     @cached_property

--- a/invenio_stats/processors.py
+++ b/invenio_stats/processors.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2017-2018 CERN.
+# Copyright (C) 2017-2019 CERN.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -19,6 +19,7 @@ from counter_robots import is_machine, is_robot
 from dateutil import parser
 from flask import current_app
 from invenio_search import current_search_client
+from invenio_search.utils import prefix_index
 from pytz import utc
 
 from .utils import get_anonymization_salt, get_geoip, obj_or_import_string
@@ -160,7 +161,8 @@ class EventsIndexer(object):
         self.queue = queue
         self.client = client or current_search_client
         self.doctype = queue.routing_key
-        self.index = '{0}-{1}'.format(prefix, self.queue.routing_key)
+        index_name = '{0}-{1}'.format(prefix, self.queue.routing_key)
+        self.index = prefix_index(index_name)
         self.suffix = suffix
         # load the preprocessors
         self.preprocessors = [

--- a/invenio_stats/queries.py
+++ b/invenio_stats/queries.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2017-2018 CERN.
+# Copyright (C) 2017-2019 CERN.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -14,6 +14,7 @@ import dateutil.parser
 import six
 from elasticsearch_dsl import Search
 from invenio_search import current_search_client
+from invenio_search.utils import prefix_index
 
 from .errors import InvalidRequestInputError
 
@@ -30,7 +31,7 @@ class ESQuery(object):
         :param client: elasticsearch client used to query.
         """
         super(ESQuery, self).__init__()
-        self.index = index
+        self.index = prefix_index(index)
         self.client = client or current_search_client
         self.query_name = query_name
         self.doc_type = doc_type

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ tests_require = [
     'python-dateutil>=2.6.0',
 ]
 
-invenio_search_version = '1.0.0'
+invenio_search_version = '1.1.0'
 
 extras_require = {
     'docs': [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2016-2018 CERN.
+# Copyright (C) 2016-2019 CERN.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -285,6 +285,12 @@ def es(app):
     finally:
         current_search_client.indices.delete(index='*')
         current_search_client.indices.delete_template('*')
+
+
+@pytest.yield_fixture()
+def index_prefix(app):
+    """Add index prefix to the app config."""
+    app.config.update(dict(SEARCH_INDEX_PREFIX='test-'))
 
 
 @pytest.yield_fixture()

--- a/tests/test_prefixing.py
+++ b/tests/test_prefixing.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2019 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Test index prefix."""
+
+import datetime
+
+from conftest import _create_file_download_event
+from elasticsearch_dsl import Search
+from helpers import get_queue_size
+from invenio_queues.proxies import current_queues
+
+from invenio_stats.contrib.registrations import register_queries
+from invenio_stats.processors import EventsIndexer, anonymize_user, \
+    flag_machines, flag_robots
+from invenio_stats.proxies import current_stats
+from invenio_stats.queries import ESDateHistogramQuery, ESTermsQuery
+from invenio_stats.tasks import aggregate_events
+
+
+def test_index_prefix(index_prefix, app, event_queues, es_with_templates):
+    es = es_with_templates
+    search = Search(using=es)
+
+    # 1) publish events in the queue
+    current_stats.publish(
+        'file-download',
+        [_create_file_download_event(date) for date in
+         [(2018, 1, 1), (2018, 1, 2), (2018, 1, 3), (2018, 1, 4)]])
+
+    queue = current_queues.queues['stats-file-download']
+    # assert get_queue_size('stats-file-download') == 4
+
+    # 2) preprocess events
+    indexer = EventsIndexer(queue, preprocessors=[flag_machines, flag_robots])
+    indexer.run()
+    es.indices.refresh(index='*')
+
+    assert get_queue_size('stats-file-download') == 0
+
+    index_prefix = app.config['SEARCH_INDEX_PREFIX']
+    index_name = index_prefix + 'events-stats-file-download'
+
+    assert es.indices.exists(index_name + '-2018-01-01')
+    assert es.indices.exists(index_name + '-2018-01-02')
+    assert es.indices.exists(index_name + '-2018-01-03')
+    assert es.indices.exists(index_name + '-2018-01-04')
+    assert es.indices.exists_alias(name=index_name)
+
+    # 3) aggregate events
+    aggregate_events(['file-download-agg'])
+    es.indices.refresh(index='*')
+    es.indices.exists(index_prefix + 'stats-file-download-2018-01')
+
+    # 4) queries
+    query_configs = register_queries()
+    histo_query = ESDateHistogramQuery(query_name='test_histo',
+                                       **query_configs[0]['query_config'])
+    results = histo_query.run(bucket_id='B0000000000000000000000000000001',
+                              file_key='test.pdf',
+                              start_date=datetime.datetime(2018, 1, 1),
+                              end_date=datetime.datetime(2018, 1, 3))
+    assert len(results['buckets'])
+    for day_result in results['buckets']:
+        assert int(day_result['value']) == 1
+
+    terms_query = ESTermsQuery(query_name='test_total_count',
+                               **query_configs[1]['query_config'])
+    results = terms_query.run(bucket_id='B0000000000000000000000000000001',
+                              start_date=datetime.datetime(2018, 1, 1),
+                              end_date=datetime.datetime(2018, 1, 7))
+    assert int(results['buckets'][0]['value']) == 4


### PR DESCRIPTION
* bump `invenio-search` to v1.1.0
* add prefix to indeces
* test index prefixes
* addresses #81 

To make the tests pass locally, install the following PRs:
- inveniosoftware/invenio-indexer#105
- inveniosoftware/invenio-records-rest#257
- inveniosoftware/invenio-search#167