### PR TITLE
aggregations:fix ES v5 support

### DIFF
--- a/invenio_stats/aggregations.py
+++ b/invenio_stats/aggregations.py
@@ -221,7 +221,7 @@ class StatAggregator(object):
             interval=self.aggregation_interval
         )
         terms = hist.bucket(
-            'terms', 'terms', field=self.aggregation_field, size=0
+            'terms', 'terms', field=self.aggregation_field, size=10000
         )
         top = terms.metric(
             'top_hit', 'top_hits', size=1, sort={'timestamp': 'desc'}


### PR DESCRIPTION
In ES v5, they removed the ability to set `size: 0` in the `terms` aggregations.

You need to specify the number of the size, depending on how many values you expect, or you can still set it to a number higher than you expect.

You can find more [here](https://github.com/elastic/elasticsearch/issues/18838)