### PR TITLE
global: pin kombu dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,10 +72,15 @@ install_requires = [
     'counter-robots>=2018.6',
     'Flask>=0.11.1',
     'invenio-cache>=1.0.0',
+    'invenio-celery>=1.1.1',
     'invenio-queues>=1.0.0a2',
     'maxminddb-geolite2>=2017.0404',
     'python-dateutil>=2.6.1',
     'python-geoip>=1.2',
+    # pin max version of `kombu` because `invenio-celery`==1.1.1
+    # requires `celery`<4.3 -> `kombu`<4.4
+    # while `invenio-queues` requires `kombu`<5
+    'kombu>=4.2.0,<4.4',
 ]
 
 packages = find_packages()


### PR DESCRIPTION
* add invenio-celery as dependency
* invenio-celery 1.1.1 pins celery to be less than 4.3 because of a bug
  with msgpack serialization. This triggers a pip conflict when
  installing kombu