### PR TITLE
global: bump invenio-celery version

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,14 @@
 Changes
 =======
 
+Version 1.0.0a16 (release 2020-02-24)
+-------------------------------------
+
+- bump celery dependency
+- pin Werkzeug version
+
+
+
 Version 1.0.0a15 (release 2019-11-27)
 -------------------------------------
 

--- a/invenio_stats/version.py
+++ b/invenio_stats/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "1.0.0a15"
+__version__ = "1.0.0a16"

--- a/setup.py
+++ b/setup.py
@@ -72,15 +72,12 @@ install_requires = [
     'counter-robots>=2018.6',
     'Flask>=0.11.1',
     'invenio-cache>=1.0.0',
-    'invenio-celery>=1.1.1',
+    'invenio-celery>=1.1.3',
     'invenio-queues>=1.0.0a2',
     'maxminddb-geolite2>=2017.0404',
     'python-dateutil>=2.6.1',
     'python-geoip>=1.2',
-    # pin max version of `kombu` because `invenio-celery`==1.1.1
-    # requires `celery`<4.3 -> `kombu`<4.4
-    # while `invenio-queues` requires `kombu`<5
-    'kombu>=4.2.0,<4.4',
+    'Werkzeug>=0.15.0,<1.0.0'
 ]
 
 packages = find_packages()


### PR DESCRIPTION
* removes the kombu pinned version