### PR TITLE
global: travis and invenio-base depencencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ notifications:
 
 dist: xenial
 
-sudo: false
-
 language: python
 
 matrix:
@@ -26,8 +24,8 @@ cache:
   - pip
 
 python:
-  - "2.7"
   - "3.6"
+  - "3.7"
 
 services:
   - redis-server
@@ -84,6 +82,6 @@ deploy:
   distributions: "sdist bdist_wheel"
   on:
     tags: true
-    python: "2.7"
+    python: "3.6"
     repo: inveniosoftware/invenio-stats
     condition: $DEPLOY = true

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,13 +9,17 @@
 Changes
 =======
 
+Version 1.0.0a17 (release 2020-03-19)
+-------------------------------------
+
+- Removes Python 2.7 support.
+- Centralizes Flask depedendency via ``invenio-base``.
+
 Version 1.0.0a16 (release 2020-02-24)
 -------------------------------------
 
 - bump celery dependency
 - pin Werkzeug version
-
-
 
 Version 1.0.0a15 (release 2019-11-27)
 -------------------------------------

--- a/invenio_stats/version.py
+++ b/invenio_stats/version.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2017-2019 CERN.
+# Copyright (C) 2017-2020 CERN.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "1.0.0a16"
+__version__ = "1.0.0a17"

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -14,3 +14,4 @@
 
 -e git+https://github.com/inveniosoftware/invenio-queues.git#egg=invenio-queues
 -e git+https://github.com/inveniosoftware/invenio-search.git#egg=invenio-search
+-e git+https://github.com/inveniosoftware/invenio-base.git#egg=invenio-base

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ tests_require = [
     'invenio-records>=1.0.0',
     'invenio-records-ui>=1.0.1',
     'isort>=4.2.15',
-    'mock>=1.3.0',
     'pydocstyle>=1.0.0',
     'pytest-cov>=1.8.0',
     'pytest-pep8>=1.0.6',
@@ -70,14 +69,13 @@ setup_requires = [
 
 install_requires = [
     'counter-robots>=2018.6',
-    'Flask>=0.11.1',
+    'invenio-base>=1.2.2',
     'invenio-cache>=1.0.0',
     'invenio-celery>=1.1.3',
     'invenio-queues>=1.0.0a2',
     'maxminddb-geolite2>=2017.0404',
     'python-dateutil>=2.6.1',
     'python-geoip>=1.2',
-    'Werkzeug>=0.15.0,<1.0.0'
 ]
 
 packages = find_packages()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ import tempfile
 import uuid
 from contextlib import contextmanager
 from copy import deepcopy
+from unittest.mock import Mock, patch
 
 # imported to make sure that
 # login_oauth2_user(valid, oauth) is included
@@ -42,7 +43,6 @@ from invenio_records import InvenioRecords
 from invenio_records.api import Record
 from invenio_search import InvenioSearch, current_search, current_search_client
 from kombu import Exchange
-from mock import Mock, patch
 from six import BytesIO
 from sqlalchemy_utils.functions import create_database, database_exists
 

--- a/tests/contrib/test_event_builders.py
+++ b/tests/contrib/test_event_builders.py
@@ -9,8 +9,7 @@
 """Test event builders."""
 
 import datetime
-
-from mock import patch
+from unittest.mock import patch
 
 from invenio_stats.contrib.event_builders import file_download_event_builder, \
     record_view_event_builder

--- a/tests/test_aggregations.py
+++ b/tests/test_aggregations.py
@@ -9,12 +9,12 @@
 """Aggregation tests."""
 
 import datetime
+from unittest.mock import patch
 
 import pytest
 from conftest import _create_file_download_event
 from elasticsearch_dsl import Index, Search
 from invenio_search import current_search
-from mock import patch
 
 from invenio_stats import current_stats
 from invenio_stats.aggregations import StatAggregator, filter_robots

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -10,6 +10,7 @@
 
 import logging
 from datetime import datetime
+from unittest.mock import patch
 
 import pytest
 from conftest import _create_file_download_event
@@ -18,7 +19,6 @@ from elasticsearch_dsl import Search
 from helpers import get_queue_size
 from invenio_queues.proxies import current_queues
 from invenio_search import current_search
-from mock import patch
 
 from invenio_stats.contrib.event_builders import build_file_unique_id, \
     file_download_event_builder

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,7 +8,7 @@
 
 """Test utility functions."""
 
-from mock import patch
+from unittest.mock import patch
 
 from invenio_stats.utils import get_geoip, get_user, obj_or_import_string
 


### PR DESCRIPTION
- updated travis and deps according to https://codimd.web.cern.ch/ZQl86wwkTp2ev_qmQXWyzQ?both
- replaced mock with standard library