### PR TITLE
views: return sensible defaults instead of None

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,13 @@
 Changes
 =======
 
+Version 1.0.0a18 (release 2020-09-01)
+-------------------------------------
+
+- Fix isort arguments
+- Filter pytest deprecation warnings
+- Set default values for metrics instead of None, when no index found
+
 Version 1.0.0a17 (release 2020-03-19)
 -------------------------------------
 

--- a/invenio_stats/version.py
+++ b/invenio_stats/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "1.0.0a17"
+__version__ = "1.0.0a18"

--- a/pytest.ini
+++ b/pytest.ini
@@ -11,3 +11,4 @@ pep8ignore =
     __init__.py E501
     docs/conf.py ALL
 addopts = --pep8 --doctest-glob="*.rst" --doctest-modules --cov=invenio_stats --cov-report=term-missing
+filterwarnings = ignore::pytest.PytestDeprecationWarning

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -10,7 +10,7 @@
 export PYTEST_ADDOPTS='docs tests invenio_stats'
 
 pydocstyle invenio_stats tests docs && \
-isort -rc -c -df && \
+isort invenio_stats tests --check-only --diff && \
 check-manifest --ignore ".travis-*" && \
 sphinx-build -qnNW docs docs/_build/html && \
 python setup.py test


### PR DESCRIPTION
- fix isort arguments
- filter pytest deprecation warnings
- default 0 value instead of None
- closes #111