### PR TITLE
Aggregations: allow `terms` bucket aggregations

### DIFF
--- a/invenio_stats/aggregations.py
+++ b/invenio_stats/aggregations.py
@@ -340,7 +340,8 @@ class StatAggregator(object):
                 ignore_cache=True,
             )
             for aggregation in results.aggregations["terms"].buckets:
-                doc = aggregation.top_hit.hits.hits[0]["_source"]
+                doc = aggregation.top_hit.hits.hits[0]["_source"].to_dict()
+                aggregation = aggregation.to_dict()
                 interval_date = datetime.strptime(
                     doc["timestamp"], "%Y-%m-%dT%H:%M:%S"
                 ).replace(**dict.fromkeys(INTERVAL_ROUNDING[self.interval], 0))

--- a/invenio_stats/aggregations.py
+++ b/invenio_stats/aggregations.py
@@ -11,7 +11,6 @@
 
 import math
 from collections import OrderedDict
-from copy import deepcopy
 from datetime import datetime
 from functools import wraps
 

--- a/invenio_stats/aggregations.py
+++ b/invenio_stats/aggregations.py
@@ -296,12 +296,15 @@ class StatAggregator(object):
     def agg_iter(self, dt):
         """Aggregate and return dictionary to be indexed in the search engine."""
         rounded_dt = format_range_dt(dt, self.interval)
-        agg_query = dsl.Search(using=self.client, index=self.event_index).filter(
-            "range",
-            # Filter for the specific interval (hour, day, month)
-            timestamp={"gte": rounded_dt, "lte": rounded_dt},
+        self.agg_query = (
+            dsl.Search(using=self.client, index=self.event_index)
+            .filter(
+                "range",
+                # Filter for the specific interval (hour, day, month)
+                timestamp={"gte": rounded_dt, "lte": rounded_dt},
+            )
+            .extra(size=0)
         )
-        self.agg_query = agg_query
 
         # apply query modifiers
         for modifier in self.query_modifiers:

--- a/invenio_stats/utils.py
+++ b/invenio_stats/utils.py
@@ -13,12 +13,11 @@ import os
 from base64 import b64encode
 from math import ceil
 
-from flask import current_app, request, session
+from flask import request, session
 from flask_login import current_user
 from geolite2 import geolite2
 from invenio_cache import current_cache
 from invenio_search.engine import dsl
-from werkzeug.utils import import_string
 
 
 def get_anonymization_salt(ts):


### PR DESCRIPTION
This PR adds support for bucket aggregations as cousins to the already supported metric aggregations.
Its main purpose is to enable simple document counts based on keywords ("how often does each value for a key occur in all events"), e.g. for the boolean `via_api` flag for `record-view` events:

reference payload:
```json
{
  "timestamp": "2023-02-21T00:00:00",
  "unique_id": "recid_mnccv-j8r20",
  "count": 3,
  "unique_count": 1,
  "via_api": {
    "true": 2,
    "false": 1
  },
  "countries": {},
  "recid": "mnccv-j8r20",
  "parent_recid": "b9jbe-qq607"
}
```


Limitations:
1) The bucket aggregations here just add "flat" (keyword count) information to the resulting aggregation, but can't be used to do nested bucketing. That would probably increase complexity a lot and isn't required right now.
2) For now, only `terms`-type bucket aggregations are supported.


## Discussion:

v1:
```json
{
  "timestamp": "2023-02-21T00:00:00",
  "unique_id": "recid_mnccv-j8r20",
  "count": 3,
  "unique_count": 1,
  "via_api": {
    "true": 2,
    "false": 1
  },
  "countries": {
    "portugal": 3,
    "china": 0
  },
  "recid": "mnccv-j8r20",
  "parent_recid": "b9jbe-qq607"
}
```

v2:
```json
{
  // ...
  "countries": [
    {"key": "portugal", "count": 3},
    {"key": "china", "count": 0}
  ]
}
```

Use cases:
1) requests on zenodo support:  from which countries was the record viewed/downloaded
2) 

Charts:
https://github.com/inveniosoftware/invenio-stats/issues/120