### PR TITLE
Replace references to Elasticsearch

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,6 @@ However, statistics can be fully customized and directly query the database.
 The services it uses are:
 
 - RabbitMQ for buffering incoming events.
-- Elasticsearch for aggregating and searching events.
+- Elasticsearch or OpenSearch for aggregating and searching events.
 
 Further documentation is available on: https://invenio-stats.readthedocs.io/

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -21,9 +21,9 @@ The main parts are:
 * **the generation of events** which can be later processed.
 
 * **the processing of events**. *Example: filtering out downloads made by bots,
-  and then indexing remaining events in Elasticsearch.*
+  and then indexing remaining events in the search engine.*
 
-* **the compression of events**. Querying too many events in an Elasticsearch
+* **the compression of events**. Querying too many events in a search
   cluster can put a big strain on it. Thus doing a compression of events makes
   later queries faster. *Example: aggregating the number of downloads per day*.
 
@@ -68,16 +68,16 @@ file downloads, record views) by plugging multiple components like this:
         }
     }
     Queue [label="Message Queue\n(RabbitMQ)", margin=0.2, shape="cds"];
-    Elasticsearch [label="Elasticsearch", shape="cylinder", height=2];
+    Search [label="Search Engine\n(ES or OS)", shape="cylinder", height=2];
 
     Emitter -> Queue [label="(2) events"];
 
     Queue -> Processor [label="(3) events"];
 
-    Processor -> Elasticsearch [label="(4) processed events"];
+    Processor -> Search [label="(4) processed events"];
 
-    Aggregator -> Elasticsearch [label="(5) processed events" dir=back];
-    Aggregator -> Elasticsearch [label="(6) aggregated statistics"];
+    Aggregator -> Search [label="(5) processed events" dir=back];
+    Aggregator -> Search [label="(6) aggregated statistics"];
     }
 
 Invenio-Stats provides an easy way to generate events whenever a signal is
@@ -121,13 +121,13 @@ The statistics are accessible via REST API.
         REST -> Query [label="(2) query"];
         Query -> REST [label="(5) statistics"];
     }
-    Elasticsearch [label="Elasticsearch", shape="cylinder", height=2];
-    Query -> Elasticsearch [label="(3) query"];
-    Elasticsearch -> Query [label="(4) stats"];
+    Search [label="Search Engine", shape="cylinder", height=2];
+    Query -> Search [label="(3) query"];
+    Search -> Query [label="(4) stats"];
     }
 
-Not every statistic of interest has to be derived from Elasticsearch. It is
-possible to retrieve statistics by just running and SQL query on the database.
+Not every statistic of interest has to be derived from the search engine.
+It is possible to retrieve statistics by just running and SQL query on the database.
 Examples:
 
 * number of users per community.
@@ -138,6 +138,6 @@ Examples:
 
 * number of new files per month.
 
-Elasticsearch is mainly used for events which happen very often and thus
+The search engine is mainly used for events which happen very often and thus
 generate a big volume of data. Invenio-Stats provide components to easily
-generate statistics out of events previously aggregated in Elasticsearch.
+generate statistics out of events previously aggregated in the search engine.

--- a/examples/app-setup.sh
+++ b/examples/app-setup.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 
-# clean elasticsearch
+# clean search indices & templates
 curl -XDELETE localhost:9200/_template/* && curl -XDELETE localhost:9200/*
 
 flask index init

--- a/examples/app.py
+++ b/examples/app.py
@@ -11,9 +11,9 @@
 
 SPHINX-START
 
-This example requires that you have an elasticsearch server running
+This example requires that you have a search server (ES/OS) running
 on localost:9200.
-WARNING: This will remove all data from your elasticsearch server.
+WARNING: This will remove all data from your search server.
 
 You should also have the `Redis` running on your machine. To know how to
 install and run `redis`, please refer to the
@@ -162,12 +162,12 @@ def events():
         day = day + timedelta(days=1)
 
     process_events(["file-download"])
-    # flush elasticsearch indices so that the events become searchable
+    # flush search indices so that the events become searchable
     current_search_client.indices.flush(index="*")
 
 
 @fixtures.command()
 def aggregations():
     aggregate_events(["file-download-agg"])
-    # flush elasticsearch indices so that the aggregations become searchable
+    # flush search indices so that the aggregations become searchable
     current_search_client.indices.flush(index="*")

--- a/invenio_stats/__init__.py
+++ b/invenio_stats/__init__.py
@@ -316,13 +316,13 @@ Again the registering function returns the configuraton for the query:
 
 .. code-block:: python
 
-    from invenio_stats.queries import ESDateHistogramQuery
+    from invenio_stats.queries import DateHistogramQuery
 
     def register_queries():
         return [
             {
                 "query_name": "bucket-file-download-histogram",
-                "cls": ESDateHistogramQuery,
+                "cls": DateHistogramQuery,
                 "params": {
                     "index": "stats-file-download",
                     "copy_fields": {
@@ -404,10 +404,10 @@ Query classes already return a common pattern of fields.
 
 The provided query classes are:
 
-* :py:class:`~invenio_stats.queries.ESDateHistogramQuery`: histogram style
+* :py:class:`~invenio_stats.queries.DateHistogramQuery`: histogram style
   aggregations.
 
-* :py:class:`~invenio_stats.queries.ESTermsQuery`: aggregation by terms
+* :py:class:`~invenio_stats.queries.TermsQuery`: aggregation by terms
   (unique field values).
 
 Those two query classes have a common format for their results:

--- a/invenio_stats/aggregations.py
+++ b/invenio_stats/aggregations.py
@@ -294,7 +294,7 @@ class StatAggregator(object):
         return res
 
     def agg_iter(self, dt):
-        """Aggregate and return dictionary to be indexed in ES."""
+        """Aggregate and return dictionary to be indexed in the search engine."""
         rounded_dt = format_range_dt(dt, self.interval)
         agg_query = dsl.Search(using=self.client, index=self.event_index).filter(
             "range",

--- a/invenio_stats/contrib/config.py
+++ b/invenio_stats/contrib/config.py
@@ -14,7 +14,7 @@ from invenio_stats.contrib.event_builders import (
     build_record_unique_id,
 )
 from invenio_stats.processors import EventsIndexer, anonymize_user, flag_robots
-from invenio_stats.queries import ESDateHistogramQuery, ESTermsQuery
+from invenio_stats.queries import DateHistogramQuery, TermsQuery
 
 EVENTS_CONFIG = {
     "file-download": {
@@ -92,7 +92,7 @@ AGGREGATIONS_CONFIG = {
 
 QUERIES_CONFIG = {
     "bucket-file-download-histogram": {
-        "cls": ESDateHistogramQuery,
+        "cls": DateHistogramQuery,
         "params": {
             "index": "stats-file-download",
             "copy_fields": {
@@ -106,7 +106,7 @@ QUERIES_CONFIG = {
         },
     },
     "bucket-file-download-total": {
-        "cls": ESTermsQuery,
+        "cls": TermsQuery,
         "params": {
             "index": "stats-file-download",
             "required_filters": {

--- a/invenio_stats/processors.py
+++ b/invenio_stats/processors.py
@@ -117,7 +117,7 @@ def flag_machines(doc):
 
 
 def hash_id(iso_timestamp, msg):
-    """Generate event id, optimized for ES."""
+    """Generate event id, optimized for the search engine."""
     return "{0}-{1}".format(
         iso_timestamp,
         hashlib.sha1(

--- a/invenio_stats/queries.py
+++ b/invenio_stats/queries.py
@@ -18,7 +18,7 @@ from invenio_search.utils import build_alias_name
 from .errors import InvalidRequestInputError
 
 
-class ESQuery(object):
+class Query(object):
     """Search query."""
 
     def __init__(self, name, index, client=None, *args, **kwargs):
@@ -50,7 +50,7 @@ class ESQuery(object):
         raise NotImplementedError()
 
 
-class ESDateHistogramQuery(ESQuery):
+class DateHistogramQuery(Query):
     """Search date histogram query."""
 
     allowed_intervals = ["year", "quarter", "month", "week", "day"]
@@ -79,7 +79,7 @@ class ESDateHistogramQuery(ESQuery):
         :param metric_fields: Dict of "destination field" ->
             tuple("metric type", "source field", "metric_options").
         """
-        super(ESDateHistogramQuery, self).__init__(*args, **kwargs)
+        super(DateHistogramQuery, self).__init__(*args, **kwargs)
         self.time_field = time_field
         self.copy_fields = copy_fields or {}
         self.query_modifiers = query_modifiers or []
@@ -200,7 +200,7 @@ class ESDateHistogramQuery(ESQuery):
         return res
 
 
-class ESTermsQuery(ESQuery):
+class TermsQuery(Query):
     """Search sum query."""
 
     def __init__(
@@ -230,7 +230,7 @@ class ESTermsQuery(ESQuery):
         :param metric_fields: Dict of "destination field" ->
             tuple("metric type", "source field").
         """
-        super(ESTermsQuery, self).__init__(*args, **kwargs)
+        super(TermsQuery, self).__init__(*args, **kwargs)
         self.time_field = time_field
         self.copy_fields = copy_fields or {}
         self.query_modifiers = query_modifiers or []
@@ -340,3 +340,9 @@ class ESTermsQuery(ESQuery):
         res = self.process_query_result(query_result, start_date, end_date)
 
         return res
+
+
+# for backwards compatibility
+ESQuery = Query
+ESDateHistogramQuery = DateHistogramQuery
+ESTermsQuery = TermsQuery

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -171,7 +171,7 @@ def base_app(events_config, aggregations_config):
                 "SQLALCHEMY_DATABASE_URI", "sqlite://"
             ),
             "SQLALCHEMY_TRACK_MODIFICATIONS": True,
-            # Bump the ES client timeout for slower environments (like Travis CI)
+            # Bump the search client timeout for slower environments (like Travis CI)
             "SEARCH_CLIENT_CONFIG": {"timeout": 30, "max_retries": 5},
             "TESTING": True,
             "OAUTH2SERVER_CLIENT_ID_SALT_LEN": 64,
@@ -227,8 +227,8 @@ def db(app):
 
 
 @pytest.fixture()
-def es(app):
-    """Provide elasticsearch access, create and clean indices.
+def search(app):
+    """Provide search engine access, create and clean indices.
 
     Don't create template so that the test or another fixture can modify the
     enabled events.
@@ -470,14 +470,14 @@ def generate_events(
 
 
 @pytest.fixture()
-def indexed_events(app, es, mock_user_ctx, request):
+def indexed_events(app, search, mock_user_ctx, request):
     """Parametrized pre indexed sample events."""
     generate_events(app=app, **request.param)
     yield
 
 
 @pytest.fixture()
-def aggregated_events(app, es, mock_user_ctx, request):
+def aggregated_events(app, search, mock_user_ctx, request):
     """Parametrized pre indexed sample events."""
     list(current_search.put_templates(ignore=[400]))
     generate_events(app=app, **request.param)
@@ -505,7 +505,7 @@ def users(app, db):
 
 
 def get_deleted_docs(index):
-    """Get all deleted docs from an ES index."""
+    """Get all deleted docs from an search index."""
     return current_search_client.indices.stats()["indices"][index]["total"]["docs"][
         "deleted"
     ]

--- a/tests/test_prefixing.py
+++ b/tests/test_prefixing.py
@@ -17,11 +17,13 @@ from invenio_queues.proxies import current_queues
 
 from invenio_stats.processors import EventsIndexer, flag_machines, flag_robots
 from invenio_stats.proxies import current_stats
-from invenio_stats.queries import ESDateHistogramQuery, ESTermsQuery
+from invenio_stats.queries import DateHistogramQuery, TermsQuery
 from invenio_stats.tasks import aggregate_events
 
 
-def test_index_prefix(config_with_index_prefix, app, es, event_queues, queries_config):
+def test_index_prefix(
+    config_with_index_prefix, app, search, event_queues, queries_config
+):
     # 1) publish events in the queue
     current_stats.publish(
         "file-download",
@@ -37,28 +39,28 @@ def test_index_prefix(config_with_index_prefix, app, es, event_queues, queries_c
     # 2) preprocess events
     indexer = EventsIndexer(queue, preprocessors=[flag_machines, flag_robots])
     indexer.run()
-    es.indices.refresh(index="*")
+    search.indices.refresh(index="*")
 
     assert get_queue_size("stats-file-download") == 0
 
     index_prefix = config_with_index_prefix["SEARCH_INDEX_PREFIX"]
     index_name = index_prefix + "events-stats-file-download"
 
-    assert es.indices.exists(index_name + "-2018-01-01")
-    assert es.indices.exists(index_name + "-2018-01-02")
-    assert es.indices.exists(index_name + "-2018-01-03")
-    assert es.indices.exists(index_name + "-2018-01-04")
-    assert es.indices.exists_alias(name=index_name)
+    assert search.indices.exists(index_name + "-2018-01-01")
+    assert search.indices.exists(index_name + "-2018-01-02")
+    assert search.indices.exists(index_name + "-2018-01-03")
+    assert search.indices.exists(index_name + "-2018-01-04")
+    assert search.indices.exists_alias(name=index_name)
 
     # 3) aggregate events
     with patch("invenio_stats.aggregations.datetime", mock_date(2018, 1, 4)):
         aggregate_events(["file-download-agg"])
-    es.indices.refresh(index="*")
-    es.indices.exists(index_prefix + "stats-file-download-2018-01")
+    search.indices.refresh(index="*")
+    search.indices.exists(index_prefix + "stats-file-download-2018-01")
 
     # 4) queries
     histo_query_name = "bucket-file-download-histogram"
-    histo_query = ESDateHistogramQuery(
+    histo_query = DateHistogramQuery(
         name=histo_query_name, **queries_config[histo_query_name]["params"]
     )
     results = histo_query.run(
@@ -72,7 +74,7 @@ def test_index_prefix(config_with_index_prefix, app, es, event_queues, queries_c
         assert int(day_result["value"]) == 1
 
     terms_query_name = "bucket-file-download-total"
-    terms_query = ESTermsQuery(
+    terms_query = TermsQuery(
         name=terms_query_name, **queries_config[terms_query_name]["params"]
     )
     results = terms_query.run(

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -355,7 +355,7 @@ def test_events_indexer_id_windowing(app, mock_event_queue):
     assert len(ids) == 3
 
 
-def test_double_clicks(app, mock_event_queue, es):
+def test_double_clicks(app, mock_event_queue, search):
     """Test that events occurring within a time window are counted as 1."""
     event_type = "file-download"
     events = [
@@ -371,15 +371,15 @@ def test_double_clicks(app, mock_event_queue, es):
     current_stats.publish(event_type, events)
     process_events(["file-download"])
     current_search.flush_and_refresh(index="*")
-    res = es.search(
+    res = search.search(
         index="events-stats-file-download-2000-06-01",
     )
     assert res["hits"]["total"]["value"] == 2
 
 
-def test_failing_processors(app, es, event_queues, caplog):
+def test_failing_processors(app, search, event_queues, caplog):
     """Test events that raise an exception when processed."""
-    search = dsl.Search(using=es)
+    search_obj = dsl.Search(using=search)
 
     current_queues.declare()
     current_stats.publish(
@@ -404,11 +404,11 @@ def test_failing_processors(app, es, event_queues, caplog):
 
     current_search.flush_and_refresh(index="*")
     assert get_queue_size("stats-file-download") == 4
-    assert not es.indices.exists("events-stats-file-download-2018-01-01")
-    assert not es.indices.exists("events-stats-file-download-2018-01-02")
-    assert not es.indices.exists("events-stats-file-download-2018-01-03")
-    assert not es.indices.exists("events-stats-file-download-2018-01-04")
-    assert not es.indices.exists_alias(name="events-stats-file-download")
+    assert not search.indices.exists("events-stats-file-download-2018-01-01")
+    assert not search.indices.exists("events-stats-file-download-2018-01-02")
+    assert not search.indices.exists("events-stats-file-download-2018-01-03")
+    assert not search.indices.exists("events-stats-file-download-2018-01-04")
+    assert not search.indices.exists_alias(name="events-stats-file-download")
 
     with caplog.at_level(logging.ERROR):
         indexer.run()  # 2nd event raises exception and is dropped
@@ -421,8 +421,8 @@ def test_failing_processors(app, es, event_queues, caplog):
 
     current_search.flush_and_refresh(index="*")
     assert get_queue_size("stats-file-download") == 0
-    assert search.index("events-stats-file-download").count() == 3
-    assert search.index("events-stats-file-download-2018-01-01").count() == 1
-    assert not es.indices.exists("events-stats-file-download-2018-01-02")
-    assert search.index("events-stats-file-download-2018-01-03").count() == 1
-    assert search.index("events-stats-file-download-2018-01-04").count() == 1
+    assert search_obj.index("events-stats-file-download").count() == 3
+    assert search_obj.index("events-stats-file-download-2018-01-01").count() == 1
+    assert not search.indices.exists("events-stats-file-download-2018-01-02")
+    assert search_obj.index("events-stats-file-download-2018-01-03").count() == 1
+    assert search_obj.index("events-stats-file-download-2018-01-04").count() == 1

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -12,7 +12,7 @@ import datetime
 
 import pytest
 
-from invenio_stats.queries import ESDateHistogramQuery, ESTermsQuery
+from invenio_stats.queries import DateHistogramQuery, TermsQuery
 
 
 @pytest.mark.parametrize(
@@ -30,7 +30,7 @@ from invenio_stats.queries import ESDateHistogramQuery, ESTermsQuery
 def test_histogram_query(app, event_queues, aggregated_events, queries_config):
     """Test histogram query daily results."""
     # reading the configuration as it is registered from registrations.py
-    histo_query = ESDateHistogramQuery(
+    histo_query = DateHistogramQuery(
         name="test_histo", **queries_config["bucket-file-download-histogram"]["params"]
     )
     results = histo_query.run(
@@ -57,7 +57,7 @@ def test_histogram_query(app, event_queues, aggregated_events, queries_config):
 )
 def test_terms_query(app, event_queues, aggregated_events, queries_config):
     """Test that the terms query returns the correct total count."""
-    terms_query = ESTermsQuery(
+    terms_query = TermsQuery(
         name="test_total_count",
         **queries_config["bucket-file-download-total"]["params"]
     )

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -13,7 +13,7 @@ from invenio_stats import current_stats
 from invenio_stats.tasks import process_events
 
 
-def test_process_events(app, es, event_queues):
+def test_process_events(app, search, event_queues):
     """Test process event."""
     current_stats.publish(
         "file-download",


### PR DESCRIPTION
Because we're not exclusively using Elasticsearch anymore (in fact, the default nowadays is OpenSearch), only referring to Elasticsearch when we're talking about search engines is incorrect.
This PR remedies this issue.