### PR TITLE
Add cached builder function for query objects

### DIFF
--- a/invenio_stats/aggregations.py
+++ b/invenio_stats/aggregations.py
@@ -11,7 +11,6 @@
 
 import math
 from collections import OrderedDict
-from copy import deepcopy
 from datetime import datetime
 from functools import wraps
 

--- a/invenio_stats/ext.py
+++ b/invenio_stats/ext.py
@@ -56,7 +56,12 @@ class _InvenioStatsState(object):
         return self._event_emitters[event_name]
 
     def get_query(self, query_name):
-        """Get the (cached) query object for the given name."""
+        """Get the (cached) query object for the given name.
+
+        Note: Because this method potentially shares references to the same query
+        objects multiple times, their internal states should not be modified after
+        construction.
+        """
         if query_name not in self._query_objects:
             query = self.queries[query_name]
             self._query_objects[query_name] = query.cls(name=query.name, **query.params)

--- a/invenio_stats/ext.py
+++ b/invenio_stats/ext.py
@@ -32,6 +32,7 @@ class _InvenioStatsState(object):
         self.app = app
         self.exchange = app.config["STATS_MQ_EXCHANGE"]
         self._event_emitters = {}
+        self._query_objects = {}
 
     @property
     def events_config(self):
@@ -46,13 +47,21 @@ class _InvenioStatsState(object):
         return self.app.config["STATS_QUERIES"]
 
     def get_event_emitter(self, event_name):
-        """Get the event emitter for the given event name."""
+        """Get the (cached) event emitter for the given event name."""
         if event_name not in self._event_emitters:
             self._event_emitters[event_name] = build_event_emitter(
                 event_name, self.events_config
             )
 
         return self._event_emitters[event_name]
+
+    def get_query(self, query_name):
+        """Get the (cached) query object for the given name."""
+        if query_name not in self._query_objects:
+            query = self.queries[query_name]
+            self._query_objects[query_name] = query.cls(name=query.name, **query.params)
+
+        return self._query_objects[query_name]
 
     @cached_property
     def events(self):

--- a/invenio_stats/utils.py
+++ b/invenio_stats/utils.py
@@ -13,12 +13,11 @@ import os
 from base64 import b64encode
 from math import ceil
 
-from flask import current_app, request, session
+from flask import request, session
 from flask_login import current_user
 from geolite2 import geolite2
 from invenio_cache import current_cache
 from invenio_search.engine import dsl
-from werkzeug.utils import import_string
 
 
 def get_anonymization_salt(ts):

--- a/invenio_stats/views.py
+++ b/invenio_stats/views.py
@@ -68,7 +68,7 @@ class StatsQueryResource(ContentNegotiatedMethodView):
             stat = config["stat"]
             params = config.get("params", {})
             try:
-                query_cfg = current_stats.queries[stat]
+                query = current_stats.get_query(stat)
             except KeyError:
                 raise UnknownQueryError(stat)
 
@@ -86,7 +86,6 @@ class StatsQueryResource(ContentNegotiatedMethodView):
                 abort(401, message)
 
             try:
-                query = query_cfg.cls(name=query_name, **query_cfg.params)
                 result[query_name] = query.run(**params)
 
             except ValueError as e:

--- a/tests/test_invenio_stats.py
+++ b/tests/test_invenio_stats.py
@@ -12,6 +12,7 @@
 from flask import Flask
 
 from invenio_stats import InvenioStats
+from invenio_stats.proxies import current_stats
 
 
 def test_version():
@@ -32,3 +33,11 @@ def test_init():
     assert "invenio-stats" not in app.extensions
     ext.init_app(app)
     assert "invenio-stats" in app.extensions
+
+
+def test_extension_get_query_cache(app, queries_config):
+    """Test if the query object cache works properly."""
+    query1 = current_stats.get_query("test-query")
+    query2 = current_stats.get_query("test-query")
+
+    assert query1 is query2


### PR DESCRIPTION
This introduces a centralized builder function for `query` objects that caches results to save a few constructors, similar to the `extension.get_event_emitter()`.