### PR TITLE
agg: fix wrong method params

### DIFF
--- a/invenio_stats/aggregations.py
+++ b/invenio_stats/aggregations.py
@@ -251,22 +251,8 @@ class StatAggregator(object):
             return None
         return parser.parse(result[0]['timestamp'])
 
-    def _split_date_range(self, lower_limit, upper_limit):
-        res = {}
-        current_interval = lower_limit
-        delta = INTERVAL_DELTAS[self.interval]
-        while current_interval < upper_limit:
-            dt_key = current_interval.strftime(
-                SUPPORTED_INTERVALS[self.interval])
-            res[dt_key] = current_interval
-            current_interval += delta
 
-        dt_key = upper_limit.strftime(
-            SUPPORTED_INTERVALS[self.interval])
-        res[dt_key] = upper_limit
-        return res
-
-    def agg_iter(self, dt):
+    def agg_iter(self, lower_limit, upper_limit):
         """Aggregate and return dictionary to be indexed in ES."""
         aggregation_data = {}
         start_date = format_range_dt(lower_limit, self.interval)


### PR DESCRIPTION
This issue was introduced by [this commit](https://github.com/inveniosoftware/invenio-stats/commit/e92f86a1bc663a68543863a7577a95630b6f16b1#diff-950fc8b8e89bc3d7d726a3377df3a17d77a5b31664bc59f0cf47cf65f3828664R269). However, the new function `_split_date_range` is not used, and it looks like very much related.
The fix is probably different (should use `_split_date_range`), but I wait for instructions from the creator.