### PR TITLE
Bump invenio-accounts dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ install_requires =
 [options.extras_require]
 tests =
     pytest-black>=0.3.0,<0.3.10
-    invenio-accounts>=2.0.0
+    invenio-accounts>=2.1.0
     invenio-db>=1.0.14
     invenio-files-rest>=1.3.0
     invenio-oauth2server>=1.3.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,7 @@ from invenio_db import InvenioDB
 from invenio_db import db as db_
 from invenio_files_rest import InvenioFilesREST
 from invenio_files_rest.models import Bucket, Location, ObjectVersion
+from invenio_i18n import InvenioI18N
 from invenio_oauth2server import InvenioOAuth2Server, InvenioOAuth2ServerREST
 from invenio_oauth2server.models import Token
 from invenio_pidstore import InvenioPIDStore
@@ -196,6 +197,7 @@ def base_app(events_config, aggregations_config):
     InvenioDB(app_)
     InvenioRecords(app_)
     InvenioFilesREST(app_)
+    InvenioI18N(app_)
     InvenioPIDStore(app_)
     InvenioCache(app_)
     InvenioQueues(app_)


### PR DESCRIPTION
Invenio-Accounts v2.1.0 brings in the Invenio-i18n dependency, which is actually needed by newer invenio-accounts versions