### PR TITLE
i18n: Fix untranslated strings in views and errors

### DIFF
--- a/invenio_stats/errors.py
+++ b/invenio_stats/errors.py
@@ -9,6 +9,7 @@
 
 """Errors used in Invenio-Stats."""
 
+from invenio_i18n import gettext as _
 from invenio_rest.errors import RESTException
 
 ##
@@ -71,6 +72,6 @@ class UnknownQueryError(RESTException):
         """
         super(RESTException, self).__init__()
         self.query_name = query_name
-        self.description = "Unknown statistic '{}'".format(query_name)
+        self.description = _("Unknown statistic '{}'").format(query_name)
 
     code = 400

--- a/invenio_stats/errors.py
+++ b/invenio_stats/errors.py
@@ -72,6 +72,8 @@ class UnknownQueryError(RESTException):
         """
         super(RESTException, self).__init__()
         self.query_name = query_name
-        self.description = _("Unknown statistic '{}'").format(query_name)
+        self.description = _(
+            "Unknown statistic '%(query_name)s'", query_name=query_name
+        )
 
     code = 400

--- a/invenio_stats/views.py
+++ b/invenio_stats/views.py
@@ -79,9 +79,10 @@ class StatsQueryResource(ContentNegotiatedMethodView):
             if permission is not None and not permission.can():
                 message = _(
                     "You do not have a permission to query the "
-                    'statistic "{}" with those '
-                    "parameters"
-                ).format(stat)
+                    'statistic "%(stat)s" with those '
+                    "parameters",
+                    stat=stat,
+                )
 
                 if current_user.is_authenticated:
                     abort(403, message)

--- a/invenio_stats/views.py
+++ b/invenio_stats/views.py
@@ -9,6 +9,7 @@
 """InvenioStats views."""
 
 from flask import Blueprint, abort, jsonify, request
+from invenio_i18n import gettext as _
 from invenio_rest.views import ContentNegotiatedMethodView
 from invenio_search.engine import search
 
@@ -38,7 +39,7 @@ class StatsQueryResource(ContentNegotiatedMethodView):
                 "GET": "application/json",
             },
             default_media_type="application/json",
-            **kwargs
+            **kwargs,
         )
 
     def post(self, **kwargs):
@@ -60,9 +61,11 @@ class StatsQueryResource(ContentNegotiatedMethodView):
                 # 'config' has to be a dictionary with mandatory 'stat' key and
                 # optional 'params' key, and nothing else
                 raise InvalidRequestInputError(
-                    "Invalid Input. It should be of the form "
-                    '{ STATISTIC_NAME: { "stat": STAT_TYPE, '
-                    '"params": STAT_PARAMS }}'
+                    _(
+                        "Invalid Input. It should be of the form "
+                        '{ STATISTIC_NAME: { "stat": STAT_TYPE, '
+                        '"params": STAT_PARAMS }}'
+                    )
                 )
 
             stat = config["stat"]
@@ -74,11 +77,11 @@ class StatsQueryResource(ContentNegotiatedMethodView):
 
             permission = current_stats.permission_factory(stat, params)
             if permission is not None and not permission.can():
-                message = (
+                message = _(
                     "You do not have a permission to query the "
                     'statistic "{}" with those '
-                    "parameters".format(stat)
-                )
+                    "parameters"
+                ).format(stat)
 
                 if current_user.is_authenticated:
                     abort(403, message)

--- a/tests/test_aggregations.py
+++ b/tests/test_aggregations.py
@@ -9,7 +9,6 @@
 """Aggregation tests."""
 
 import datetime
-from turtle import pd
 from unittest.mock import patch
 
 import pytest


### PR DESCRIPTION
### Description

There are untranslated permission and usage errors in views.py and errors.py. 
This PR fixes those by using `gettext` from invenio-i18n.


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
