### PR TITLE
feat(config): add STATS_EVENTS_USE_NAIVE_UTC_DATETIME flag

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,13 @@
 Changes
 =======
 
+Version v6.1.0 (released 2026-01-29)
+
+- feat(config): add STATS_EVENTS_UTC_DATETIME_ENABLED flag
+  Introduce STATS_EVENTS_UTC_DATETIME_ENABLED (default: False) to strip
+  tzinfo from event timestamps at build time. Set to True to opt-in to
+  timezone-aware UTC datetimes.
+
 Version v6.0.0 (released 2026-01-29)
 
 - chore(setup): bump dependencies

--- a/invenio_stats/__init__.py
+++ b/invenio_stats/__init__.py
@@ -441,7 +441,7 @@ Invenio-Stats provides some default statistics which can be found in
 from .ext import InvenioStats
 from .proxies import current_stats
 
-__version__ = "6.0.0"
+__version__ = "6.1.0"
 
 __all__ = (
     "__version__",

--- a/invenio_stats/config.py
+++ b/invenio_stats/config.py
@@ -76,3 +76,11 @@ STATS_REGISTER_INDEX_TEMPLATES = False
 
 Default behaviour will register the templates as search templates.
 """
+
+STATS_EVENTS_UTC_DATETIME_ENABLED = False
+"""Enable timezone-aware UTC datetimes for event timestamps.
+
+When set to ``False`` (default), naive UTC datetimes are used (tzinfo is
+stripped via ``datetime.replace(tzinfo=None)``). Set to ``True`` to use
+timezone-aware UTC datetimes with explicit UTC timezone information.
+"""

--- a/invenio_stats/contrib/event_builders.py
+++ b/invenio_stats/contrib/event_builders.py
@@ -12,9 +12,17 @@
 
 import datetime
 
-from flask import request
+from flask import current_app, request
 
 from ..utils import get_user
+
+
+def _build_timestamp():
+    """Build an event timestamp, stripping tzinfo if configured."""
+    ts = datetime.datetime.now(datetime.timezone.utc)
+    if not current_app.config["STATS_EVENTS_UTC_DATETIME_ENABLED"]:
+        ts = ts.replace(tzinfo=None)
+    return ts.isoformat()
 
 
 def file_download_event_builder(event, sender_app, obj=None, **kwargs):
@@ -22,7 +30,7 @@ def file_download_event_builder(event, sender_app, obj=None, **kwargs):
     event.update(
         {
             # When:
-            "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            "timestamp": _build_timestamp(),
             # What:
             "bucket_id": str(obj.bucket_id),
             "file_id": str(obj.file_id),
@@ -53,7 +61,7 @@ def record_view_event_builder(event, sender_app, pid=None, record=None, **kwargs
     event.update(
         {
             # When:
-            "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            "timestamp": _build_timestamp(),
             # What:
             "record_id": str(record.id),
             "pid_type": pid.pid_type,

--- a/tests/contrib/test_event_builders.py
+++ b/tests/contrib/test_event_builders.py
@@ -43,7 +43,9 @@ def test_file_download_event_builder(app, mock_user_ctx, sequential_ids, objects
             file_download_event_builder(event, app, file_obj)
         assert event == {
             # When:
-            "timestamp": NewDate.now(tzinfo=timezone.utc).isoformat(),
+            "timestamp": NewDate.now(tzinfo=timezone.utc)
+            .replace(tzinfo=None)
+            .isoformat(),
             # What:
             "bucket_id": str(file_obj.bucket_id),
             "file_id": str(file_obj.file_id),
@@ -63,7 +65,9 @@ def test_record_view_event_builder(app, mock_user_ctx, record, pid):
             record_view_event_builder(event, app, pid, record)
         assert event == {
             # When:
-            "timestamp": NewDate.now(tzinfo=timezone.utc).isoformat(),
+            "timestamp": NewDate.now(tzinfo=timezone.utc)
+            .replace(tzinfo=None)
+            .isoformat(),
             # What:
             "record_id": str(record.id),
             "pid_type": pid.pid_type,
@@ -72,3 +76,38 @@ def test_record_view_event_builder(app, mock_user_ctx, record, pid):
             # Who:
             **get_user(),
         }
+
+
+def test_file_download_event_builder_aware_datetime(
+    app, mock_user_ctx, sequential_ids, objects
+):
+    """Test file-download event builder produces aware UTC datetime when enabled."""
+    file_obj = objects[0]
+    file_obj.bucket_id = sequential_ids[0]
+
+    app.config["STATS_EVENTS_UTC_DATETIME_ENABLED"] = True
+    try:
+        with app.test_request_context(headers=headers):
+            event = {}
+            with patch("datetime.datetime", NewDate):
+                file_download_event_builder(event, app, file_obj)
+            assert event["timestamp"] == NewDate.now(tzinfo=timezone.utc).isoformat()
+            # Aware ISO format must contain timezone offset
+            assert "+00:00" in event["timestamp"]
+    finally:
+        app.config["STATS_EVENTS_UTC_DATETIME_ENABLED"] = False
+
+
+def test_record_view_event_builder_aware_datetime(app, mock_user_ctx, record, pid):
+    """Test record-view event builder produces aware UTC datetime when enabled."""
+    app.config["STATS_EVENTS_UTC_DATETIME_ENABLED"] = True
+    try:
+        with app.test_request_context(headers=headers):
+            event = {}
+            with patch("datetime.datetime", NewDate):
+                record_view_event_builder(event, app, pid, record)
+            assert event["timestamp"] == NewDate.now(tzinfo=timezone.utc).isoformat()
+            # Aware ISO format must contain timezone offset
+            assert "+00:00" in event["timestamp"]
+    finally:
+        app.config["STATS_EVENTS_UTC_DATETIME_ENABLED"] = False


### PR DESCRIPTION
Introduce STATS_EVENTS_USE_NAIVE_UTC_DATETIME (default: True) to strip tzinfo from event timestamps at build time. Set to False to opt-in to timezone-aware UTC datetimes.
