### PR TITLE
feat(aggregations): add opt-in batch_bookmark and incremental modes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,23 @@
 Changes
 =======
 
+Version v6.2.0 (unreleased)
+
+- feat(aggregations): add opt-in ``batch_bookmark`` flag on
+  ``StatAggregator``. When enabled, the aggregator writes a bookmark
+  after every successful interval instead of once at the end of
+  ``StatAggregator.run``, so a worker killed mid-loop only loses
+  the interval currently in progress.
+- feat(aggregations): add opt-in ``incremental`` flag on
+  ``StatAggregator``. When enabled (and a previous bookmark exists),
+  ``StatAggregator.agg_iter`` first looks up the field values whose
+  events were touched since the bookmark, then re-aggregates only
+  those values. Cuts steady-state read cost on busy deployments where
+  the bookmark cadence is much shorter than the aggregation interval.
+  A new ``affected_partition_size`` parameter (default ``10000``)
+  controls how the affected set is chunked across ``terms`` filters.
+- All new flags default to off; existing behavior is preserved.
+
 Version v6.1.3 (released 2026-04-30)
 
 - fix(stats): warm event cache on finalization

--- a/invenio_stats/aggregations.py
+++ b/invenio_stats/aggregations.py
@@ -103,6 +103,9 @@ class StatAggregator(object):
         interval="day",
         index_interval="month",
         max_bucket_size=10000,
+        batch_bookmark=False,
+        incremental=False,
+        affected_partition_size=10000,
     ):
         """Construct aggregator instance.
 
@@ -120,6 +123,24 @@ class StatAggregator(object):
         :param interval: aggregation time window. default: month.
         :param index_interval: time window of the search indices which
             will contain the resulting aggregations.
+        :param batch_bookmark: when True, write a bookmark after each
+            interval iteration of :meth:`run` instead of once at the end.
+            This makes the aggregator durable across interruptions: a task
+            killed mid-loop only loses the interval currently in progress.
+        :param incremental: when True, :meth:`agg_iter` first looks up the
+            field values whose events were touched since
+            ``previous_bookmark``, then re-aggregates only those values.
+            Falls back to the full-interval scan on cold start (no previous
+            bookmark). Requires the event docs to carry an
+            ``updated_timestamp`` field (introduced in v4.0.0). Events
+            backfilled with an old ``timestamp`` but a recent
+            ``updated_timestamp`` are not picked up by the interval loop in
+            :meth:`run`, because the loop only visits intervals between
+            ``previous_bookmark`` and now.
+        :param affected_partition_size: the maximum number of field values
+            per ``terms`` filter when re-aggregating the affected set. The
+            hard upstream ceiling is ``index.max_terms_count`` (OS default
+            65,536).
         """
         self.name = name
         self.event = event
@@ -138,6 +159,9 @@ class StatAggregator(object):
         )
         self.bookmark_api = BookmarkAPI(self.client, self.name, self.interval)
         self.max_bucket_size = max_bucket_size
+        self.batch_bookmark = batch_bookmark
+        self.incremental = incremental
+        self.affected_partition_size = affected_partition_size
 
         if any(v not in ALLOWED_METRICS for k, (v, _, _) in self.metric_fields.items()):
             raise (
@@ -198,22 +222,119 @@ class StatAggregator(object):
         res[dt_key] = upper_limit
         return res
 
-    def agg_iter(self, dt, previous_bookmark):
-        """Aggregate and return dictionary to be indexed in the search engine."""
-        rounded_dt = format_range_dt(dt, self.interval)
-        agg_query = (
-            dsl.Search(using=self.client, index=self.event_index).filter(
-                # Filter for the specific interval (hour, day, month)
-                "term",
-                timestamp=rounded_dt,
+    def _bucket_to_action(self, bucket, previous_bookmark):
+        """Build a bulk-index action from one terms bucket.
+
+        Returns ``None`` when the bucket has not been touched since
+        ``previous_bookmark`` (and therefore the existing aggregation doc is
+        already up to date), so callers can ``filter`` it out.
+        """
+        doc = bucket.top_hit.hits.hits[0]["_source"].to_dict()
+        aggregation = bucket.to_dict()
+        interval_date = datetime.strptime(
+            doc["timestamp"], "%Y-%m-%dT%H:%M:%S"
+        ).replace(**dict.fromkeys(INTERVAL_ROUNDING[self.interval], 0))
+
+        # Skip events that have been previously aggregated.
+        # The `updated_timestamp` field was introduced with v4.0.0, and it
+        # will not exist in events created earlier.
+        last_update_aggr = aggregation["last_update"].get("value_as_string", None)
+        if last_update_aggr and previous_bookmark:
+            last_date = datetime.fromisoformat(last_update_aggr.rstrip("Z")).replace(
+                tzinfo=timezone.utc
             )
-            # we're only interested in the aggregated results but not the search hits,
-            # so we tell the search to ignore them to save some bandwidth
+            if last_date < previous_bookmark:
+                return None
+
+        aggregation_data = {
+            "timestamp": interval_date.isoformat(),
+            self.field: aggregation["key"],
+            "count": aggregation["doc_count"],
+            "updated_timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+
+        for f in self.metric_fields:
+            aggregation_data[f] = aggregation[f]["value"]
+
+        for destination, source in self.copy_fields.items():
+            if isinstance(source, str):
+                aggregation_data[destination] = doc[source]
+            else:
+                aggregation_data[destination] = source(doc, aggregation_data)
+
+        index_name = prefix_index(
+            "stats-{0}-{1}".format(
+                self.event, interval_date.strftime(self.index_name_suffix)
+            )
+        )
+        return {
+            "_id": "{0}-{1}".format(
+                aggregation["key"], interval_date.strftime(self.doc_id_suffix)
+            ),
+            "_index": index_name,
+            "_source": aggregation_data,
+        }
+
+    def agg_iter(self, dt, previous_bookmark):
+        """Aggregate and yield bulk-index actions for the given interval."""
+        if self.incremental and previous_bookmark:
+            yield from self._agg_iter_incremental(dt, previous_bookmark)
+        else:
+            yield from self._agg_iter_full(dt, previous_bookmark)
+
+    def _interval_search(self, rounded_dt):
+        """Build a size=0 search filtered to one interval with query modifiers applied.
+
+        This is the shared base for both the full-scan and incremental
+        aggregation queries, plus the affected-set lookup.
+        """
+        q = (
+            dsl.Search(using=self.client, index=self.event_index).filter(
+                "term", timestamp=rounded_dt
+            )
+            # We only want aggregated results, not the underlying hits, so
+            # tell the engine to skip them and save bandwidth.
             .extra(size=0)
         )
-        # apply query modifiers
         for modifier in self.query_modifiers:
-            agg_query = modifier(agg_query)
+            q = modifier(q)
+        return q
+
+    def _attach_terms_aggregation(self, search, include, size):
+        """Attach the canonical ``terms`` aggregation with its metrics.
+
+        Used by both the full-scan and incremental re-aggregation paths so
+        the per-bucket payload (top_hit, configured metric_fields, last
+        ``updated_timestamp``) stays identical between them.
+        """
+        terms = search.aggs.bucket(
+            "terms",
+            "terms",
+            field=self.field,
+            include=include,
+            size=size,
+        )
+        terms.metric("top_hit", "top_hits", size=1, sort={"timestamp": "desc"})
+        for dst, (metric, src, opts) in self.metric_fields.items():
+            terms.metric(dst, metric, field=src, **opts)
+        terms.metric("last_update", "max", field="updated_timestamp")
+        return terms
+
+    def _iter_bucket_actions(self, search, previous_bookmark):
+        """Execute the aggregation and yield bulk-index actions per bucket."""
+        # Without ignore_cache, repeated executions on a mutated query body
+        # (e.g. partition rotation in the full-scan path) hit the response
+        # cache and return stale results.
+        results = search.execute(ignore_cache=True)
+        for bucket in results.aggregations["terms"].buckets:
+            action = self._bucket_to_action(bucket, previous_bookmark)
+            if action is not None:
+                yield action
+
+    def _agg_iter_full(self, dt, previous_bookmark):
+        """Full-interval scan: partition the whole interval and re-aggregate."""
+        rounded_dt = format_range_dt(dt, self.interval)
+        agg_query = self._interval_search(rounded_dt)
 
         total_buckets = get_bucket_size(
             self.client,
@@ -222,80 +343,50 @@ class StatAggregator(object):
             start_date=rounded_dt,
             end_date=rounded_dt,
         )
-
         num_partitions = max(
             int(math.ceil(float(total_buckets) / self.max_bucket_size)), 1
         )
         for p in range(num_partitions):
-            terms = agg_query.aggs.bucket(
-                "terms",
-                "terms",
-                field=self.field,
+            self._attach_terms_aggregation(
+                agg_query,
                 include={"partition": p, "num_partitions": num_partitions},
                 size=self.max_bucket_size,
             )
-            terms.metric("top_hit", "top_hits", size=1, sort={"timestamp": "desc"})
-            for dst, (metric, src, opts) in self.metric_fields.items():
-                terms.metric(dst, metric, field=src, **opts)
-            # Let's get also the last time that the event happened
-            terms.metric("last_update", "max", field="updated_timestamp")
+            yield from self._iter_bucket_actions(agg_query, previous_bookmark)
 
-            results = agg_query.execute(
-                # NOTE: Without this, the aggregation changes above, do not
-                # invalidate the search's response cache, and thus you would
-                # always get the same results for each partition.
-                ignore_cache=True,
-            )
-            for aggregation in results.aggregations["terms"].buckets:
-                doc = aggregation.top_hit.hits.hits[0]["_source"].to_dict()
-                aggregation = aggregation.to_dict()
-                interval_date = datetime.strptime(
-                    doc["timestamp"], "%Y-%m-%dT%H:%M:%S"
-                ).replace(**dict.fromkeys(INTERVAL_ROUNDING[self.interval], 0))
+    def _affected_field_values(self, dt, previous_bookmark):
+        """Return field values whose events were touched since the bookmark.
 
-                # Skip events that have been previously aggregated.
-                # The`updated_timestamp` field was introduced with v4.0.0, and it will
-                # not exist in events created earlier
-                last_update_aggr = aggregation["last_update"].get(
-                    "value_as_string", None
-                )
-                if last_update_aggr and previous_bookmark:
-                    last_date = datetime.fromisoformat(
-                        last_update_aggr.rstrip("Z")
-                    ).replace(tzinfo=timezone.utc)
-                    if last_date < previous_bookmark:
-                        continue
+        Reuses ``query_modifiers`` so the affected set stays consistent with
+        the re-aggregation set. A record touched only by robots in the last
+        interval will not appear here (correctly) and its existing
+        robot-filtered aggregation doc will not be refreshed.
+        """
+        rounded_dt = format_range_dt(dt, self.interval)
+        q = self._interval_search(rounded_dt).filter(
+            "range",
+            updated_timestamp={"gte": previous_bookmark.isoformat()},
+        )
+        q.aggs.bucket("affected", "terms", field=self.field, size=self.max_bucket_size)
+        res = q.execute(ignore_cache=True)
+        return [b.key for b in res.aggregations.affected.buckets]
 
-                aggregation_data = {}
-                aggregation_data["timestamp"] = interval_date.isoformat()
-                aggregation_data[self.field] = aggregation["key"]
-                aggregation_data["count"] = aggregation["doc_count"]
-                aggregation_data["updated_timestamp"] = datetime.now(
-                    timezone.utc
-                ).isoformat()
+    def _agg_iter_incremental(self, dt, previous_bookmark):
+        """Aggregate only field values touched since ``previous_bookmark``."""
+        affected = self._affected_field_values(dt, previous_bookmark)
+        if not affected:
+            return
 
-                if self.metric_fields:
-                    for f in self.metric_fields:
-                        aggregation_data[f] = aggregation[f]["value"]
+        rounded_dt = format_range_dt(dt, self.interval)
+        for start in range(0, len(affected), self.affected_partition_size):
+            chunk = affected[start : start + self.affected_partition_size]
+            yield from self._agg_iter_chunk(rounded_dt, chunk, previous_bookmark)
 
-                for destination, source in self.copy_fields.items():
-                    if isinstance(source, str):
-                        aggregation_data[destination] = doc[source]
-                    else:
-                        aggregation_data[destination] = source(doc, aggregation_data)
-
-                index_name = prefix_index(
-                    "stats-{0}-{1}".format(
-                        self.event, interval_date.strftime(self.index_name_suffix)
-                    )
-                )
-                yield {
-                    "_id": "{0}-{1}".format(
-                        aggregation["key"], interval_date.strftime(self.doc_id_suffix)
-                    ),
-                    "_index": index_name,
-                    "_source": aggregation_data,
-                }
+    def _agg_iter_chunk(self, rounded_dt, chunk, previous_bookmark):
+        """Re-aggregate one chunk of affected field values."""
+        q = self._interval_search(rounded_dt).filter("terms", **{self.field: chunk})
+        self._attach_terms_aggregation(q, include=chunk, size=len(chunk))
+        yield from self._iter_bucket_actions(q, previous_bookmark)
 
     def _upper_limit(self, end_date):
         max_ = datetime.max.replace(tzinfo=timezone.utc)
@@ -305,7 +396,13 @@ class StatAggregator(object):
         )
 
     def run(self, start_date=None, end_date=None, update_bookmark=True):
-        """Calculate statistics aggregations."""
+        """Calculate statistics aggregations.
+
+        When ``batch_bookmark`` is True, a bookmark is written after every
+        successful interval iteration so a kill mid-loop only loses the
+        interval currently in progress. Otherwise the historical behaviour
+        of writing one bookmark at the end of the run is preserved.
+        """
         # If no events have been indexed there is nothing to aggregate
         if not dsl.Index(self.event_index, using=self.client).exists():
             return
@@ -322,8 +419,7 @@ class StatAggregator(object):
         dates = self._split_date_range(lower_limit, upper_limit)
         # Let's get the timestamp before we start the aggregation.
         # This will be used for the next iteration. Some events might be processed twice
-        if not end_date:
-            end_date = datetime.now(timezone.utc).isoformat()
+        end_clock = end_date or datetime.now(timezone.utc).isoformat()
 
         results = []
         for dt_key, dt in sorted(dates.items()):
@@ -335,8 +431,15 @@ class StatAggregator(object):
                     chunk_size=50,
                 )
             )
-        if update_bookmark:
-            self.bookmark_api.set_bookmark(end_date)
+            if update_bookmark and self.batch_bookmark:
+                interval_end = min(
+                    dt + INTERVAL_DELTAS[self.interval],
+                    datetime.now(timezone.utc),
+                )
+                self.bookmark_api.set_bookmark(interval_end.isoformat())
+
+        if update_bookmark and not self.batch_bookmark:
+            self.bookmark_api.set_bookmark(end_clock)
         return results
 
     def list_bookmarks(self, start_date=None, end_date=None, limit=None):

--- a/tests/test_aggregations.py
+++ b/tests/test_aggregations.py
@@ -350,3 +350,353 @@ def test_metric_aggregations(app, search_clear, event_queues):
     assert results[0].count == 12  # 3 views over 4 differnet hour slices
     assert results[0].unique_count == 4  # 4 different hour slices accessed
     assert results[0].volume == 9000 * 12
+
+
+@pytest.mark.parametrize(
+    "indexed_events",
+    [
+        {
+            "file_number": 1,
+            "event_number": 1,
+            "robot_event_number": 0,
+            "start_date": datetime.date(2017, 1, 1),
+            "end_date": datetime.date(2017, 1, 3),
+        }
+    ],
+    indirect=["indexed_events"],
+)
+def test_batch_bookmark_advances_per_interval(app, search_clear, indexed_events):
+    """Test that batch_bookmark writes one bookmark per processed interval."""
+    aggregator = StatAggregator(
+        name="file-download-agg",
+        client=search_clear,
+        event="file-download",
+        field="file_id",
+        interval="day",
+        batch_bookmark=True,
+    )
+    with patch("invenio_stats.aggregations.datetime", mock_date(2017, 1, 4)):
+        aggregator.run(
+            start_date=datetime.datetime(2017, 1, 1, tzinfo=datetime.timezone.utc),
+            end_date=datetime.datetime(
+                2017, 1, 3, 23, 59, 59, tzinfo=datetime.timezone.utc
+            ),
+        )
+    current_search.flush_and_refresh(index="*")
+
+    bookmarks = list(aggregator.list_bookmarks())
+    assert len(bookmarks) == 3
+    dates = sorted(b.date for b in bookmarks)
+    assert dates[0].startswith("2017-01-02")
+    assert dates[1].startswith("2017-01-03")
+    assert dates[2].startswith("2017-01-04")
+
+
+@pytest.mark.parametrize(
+    "indexed_events",
+    [
+        {
+            "file_number": 1,
+            "event_number": 1,
+            "robot_event_number": 0,
+            "start_date": datetime.date(2017, 1, 1),
+            "end_date": datetime.date(2017, 1, 3),
+        }
+    ],
+    indirect=["indexed_events"],
+)
+def test_batch_bookmark_resume_after_partial_run(app, search_clear, indexed_events):
+    """Test that a failure mid-loop preserves bookmarks for completed intervals."""
+    aggregator = StatAggregator(
+        name="file-download-agg",
+        client=search_clear,
+        event="file-download",
+        field="file_id",
+        interval="day",
+        batch_bookmark=True,
+    )
+
+    # Simulate a worker kill on the third interval
+    real_agg_iter = aggregator.agg_iter
+    call_count = {"n": 0}
+
+    def fail_on_third_interval(dt, previous_bookmark):
+        call_count["n"] += 1
+        if call_count["n"] > 2:
+            raise RuntimeError("simulated worker kill")
+        yield from real_agg_iter(dt, previous_bookmark)
+
+    aggregator.agg_iter = fail_on_third_interval
+
+    with patch("invenio_stats.aggregations.datetime", mock_date(2017, 1, 4)):
+        with pytest.raises(RuntimeError):
+            aggregator.run(
+                start_date=datetime.datetime(2017, 1, 1, tzinfo=datetime.timezone.utc),
+                end_date=datetime.datetime(
+                    2017, 1, 3, 23, 59, 59, tzinfo=datetime.timezone.utc
+                ),
+            )
+    current_search.flush_and_refresh(index="*")
+
+    # The first two intervals' bookmarks should be present
+    bookmarks = list(aggregator.list_bookmarks())
+    assert len(bookmarks) == 2
+    assert max(b.date for b in bookmarks).startswith("2017-01-03")
+
+    # Re-run from the saved bookmark and confirm all three days are aggregated
+    aggregator.agg_iter = real_agg_iter
+    with patch("invenio_stats.aggregations.datetime", mock_date(2017, 1, 4)):
+        aggregator.run(
+            end_date=datetime.datetime(
+                2017, 1, 3, 23, 59, 59, tzinfo=datetime.timezone.utc
+            ),
+        )
+    current_search.flush_and_refresh(index="*")
+
+    results = (
+        dsl.Search(using=search_clear, index="stats-file-download")
+        .sort("timestamp")
+        .execute()
+    )
+    timestamps = [r.timestamp[:10] for r in results if "file_id" in r]
+    assert timestamps == ["2017-01-01", "2017-01-02", "2017-01-03"]
+
+
+def test_incremental_skips_unchanged_records(app, search_clear, mock_event_queue):
+    """Test that the affected-set lookup returns only files touched since the bookmark."""
+    # Seed one event per file for five files
+    mock_event_queue.consume.return_value = [
+        _create_file_download_event(
+            (2017, 1, 2, 8),
+            file_id="F000000000000000000000000000000{}".format(i),
+        )
+        for i in range(1, 6)
+    ]
+    with patch("invenio_stats.processors.datetime", mock_date(2017, 1, 2, 8)):
+        indexer = EventsIndexer(mock_event_queue)
+        indexer.run()
+    current_search.flush_and_refresh(index="*")
+
+    bookmark = datetime.datetime(2017, 1, 2, 12, tzinfo=datetime.timezone.utc)
+
+    # Add new events for files 1 and 2 only, after the bookmark
+    mock_event_queue.consume.return_value = [
+        _create_file_download_event(
+            (2017, 1, 2, 14),
+            file_id="F000000000000000000000000000000{}".format(i),
+        )
+        for i in (1, 2)
+    ]
+    with patch("invenio_stats.processors.datetime", mock_date(2017, 1, 2, 14)):
+        indexer = EventsIndexer(mock_event_queue)
+        indexer.run()
+    current_search.flush_and_refresh(index="*")
+
+    aggregator = StatAggregator(
+        name="file-download-agg",
+        client=search_clear,
+        event="file-download",
+        field="file_id",
+        interval="day",
+        incremental=True,
+    )
+    affected = aggregator._affected_field_values(
+        datetime.datetime(2017, 1, 2, tzinfo=datetime.timezone.utc), bookmark
+    )
+    assert set(affected) == {
+        "F0000000000000000000000000000001",
+        "F0000000000000000000000000000002",
+    }
+
+
+def test_incremental_matches_full_results(app, search_clear, mock_event_queue):
+    """Test that the incremental and full paths produce identical aggregation docs."""
+    # Seed one event per file for five files
+    mock_event_queue.consume.return_value = [
+        _create_file_download_event(
+            (2017, 1, 2, 8),
+            file_id="F000000000000000000000000000000{}".format(i),
+        )
+        for i in range(1, 6)
+    ]
+    with patch("invenio_stats.processors.datetime", mock_date(2017, 1, 2, 8)):
+        indexer = EventsIndexer(mock_event_queue)
+        indexer.run()
+    current_search.flush_and_refresh(index="*")
+
+    # Initial aggregation run (full scan), establishes a bookmark
+    aggregator = StatAggregator(
+        name="file-download-agg",
+        client=search_clear,
+        event="file-download",
+        field="file_id",
+        interval="day",
+    )
+    with patch("invenio_stats.aggregations.datetime", mock_date(2017, 1, 2, 12)):
+        aggregator.run()
+    current_search.flush_and_refresh(index="*")
+
+    # Add new events for files 1 and 2
+    mock_event_queue.consume.return_value = [
+        _create_file_download_event(
+            (2017, 1, 2, 14),
+            file_id="F000000000000000000000000000000{}".format(i),
+        )
+        for i in (1, 2)
+    ]
+    with patch("invenio_stats.processors.datetime", mock_date(2017, 1, 2, 14)):
+        indexer = EventsIndexer(mock_event_queue)
+        indexer.run()
+    current_search.flush_and_refresh(index="*")
+
+    # Incremental run on top of the existing aggregation
+    incremental = StatAggregator(
+        name="file-download-agg",
+        client=search_clear,
+        event="file-download",
+        field="file_id",
+        interval="day",
+        incremental=True,
+    )
+    with patch("invenio_stats.aggregations.datetime", mock_date(2017, 1, 2, 18)):
+        incremental.run()
+    current_search.flush_and_refresh(index="*")
+
+    incremental_docs = {
+        h["_id"]: {k: v for k, v in h["_source"].items() if k != "updated_timestamp"}
+        for h in search_clear.search(index="stats-file-download")["hits"]["hits"]
+    }
+
+    # Wipe aggregation docs and the bookmark, then re-run from scratch (full scan)
+    aggregator.delete()
+    current_search.flush_and_refresh(index="*")
+    with patch("invenio_stats.aggregations.datetime", mock_date(2017, 1, 2, 18)):
+        aggregator.run()
+    current_search.flush_and_refresh(index="*")
+
+    full_docs = {
+        h["_id"]: {k: v for k, v in h["_source"].items() if k != "updated_timestamp"}
+        for h in search_clear.search(index="stats-file-download")["hits"]["hits"]
+    }
+    assert incremental_docs == full_docs
+    assert len(incremental_docs) == 5
+    counts = {doc["file_id"]: doc["count"] for doc in incremental_docs.values()}
+    assert counts["F0000000000000000000000000000001"] == 2
+    assert counts["F0000000000000000000000000000002"] == 2
+    for i in (3, 4, 5):
+        assert counts["F000000000000000000000000000000{}".format(i)] == 1
+
+
+def test_incremental_cold_start_falls_back(app, search_clear, mock_event_queue):
+    """Test that incremental falls back to the full scan when there is no bookmark."""
+    mock_event_queue.consume.return_value = [
+        _create_file_download_event(
+            (2017, 1, 2, 8),
+            file_id="F000000000000000000000000000000{}".format(i),
+        )
+        for i in range(1, 6)
+    ]
+    with patch("invenio_stats.processors.datetime", mock_date(2017, 1, 2, 8)):
+        indexer = EventsIndexer(mock_event_queue)
+        indexer.run()
+    current_search.flush_and_refresh(index="*")
+
+    aggregator = StatAggregator(
+        name="file-download-agg",
+        client=search_clear,
+        event="file-download",
+        field="file_id",
+        interval="day",
+        incremental=True,
+    )
+
+    full_calls = []
+    incremental_calls = []
+    real_full = StatAggregator._agg_iter_full
+    real_incremental = StatAggregator._agg_iter_incremental
+
+    def track_full(self, dt, previous_bookmark):
+        full_calls.append((dt, previous_bookmark))
+        yield from real_full(self, dt, previous_bookmark)
+
+    def track_incremental(self, dt, previous_bookmark):
+        incremental_calls.append((dt, previous_bookmark))
+        yield from real_incremental(self, dt, previous_bookmark)
+
+    with patch.object(StatAggregator, "_agg_iter_full", track_full), patch.object(
+        StatAggregator, "_agg_iter_incremental", track_incremental
+    ), patch("invenio_stats.aggregations.datetime", mock_date(2017, 1, 2, 12)):
+        aggregator.run()
+
+    assert len(full_calls) >= 1
+    assert incremental_calls == []
+
+
+def test_incremental_partitions_large_affected_set(app, search_clear, mock_event_queue):
+    """Test that affected_partition_size splits the affected set across queries."""
+    mock_event_queue.consume.return_value = [
+        _create_file_download_event(
+            (2017, 1, 2, 8),
+            file_id="F000000000000000000000000000000{}".format(i),
+        )
+        for i in range(1, 6)
+    ]
+    with patch("invenio_stats.processors.datetime", mock_date(2017, 1, 2, 8)):
+        indexer = EventsIndexer(mock_event_queue)
+        indexer.run()
+    current_search.flush_and_refresh(index="*")
+
+    # Initial run establishes the bookmark
+    seed = StatAggregator(
+        name="file-download-agg",
+        client=search_clear,
+        event="file-download",
+        field="file_id",
+        interval="day",
+    )
+    with patch("invenio_stats.aggregations.datetime", mock_date(2017, 1, 2, 12)):
+        seed.run()
+    current_search.flush_and_refresh(index="*")
+
+    # Touch all five files after the bookmark
+    mock_event_queue.consume.return_value = [
+        _create_file_download_event(
+            (2017, 1, 2, 14),
+            file_id="F000000000000000000000000000000{}".format(i),
+        )
+        for i in range(1, 6)
+    ]
+    with patch("invenio_stats.processors.datetime", mock_date(2017, 1, 2, 14)):
+        indexer = EventsIndexer(mock_event_queue)
+        indexer.run()
+    current_search.flush_and_refresh(index="*")
+
+    aggregator = StatAggregator(
+        name="file-download-agg",
+        client=search_clear,
+        event="file-download",
+        field="file_id",
+        interval="day",
+        incremental=True,
+        affected_partition_size=2,
+    )
+
+    chunks_seen = []
+    real_chunk = StatAggregator._agg_iter_chunk
+
+    def track_chunk(self, rounded_dt, chunk, previous_bookmark):
+        chunks_seen.append(list(chunk))
+        yield from real_chunk(self, rounded_dt, chunk, previous_bookmark)
+
+    with patch.object(StatAggregator, "_agg_iter_chunk", track_chunk), patch(
+        "invenio_stats.aggregations.datetime", mock_date(2017, 1, 2, 18)
+    ):
+        aggregator.run()
+
+    assert len(chunks_seen) == 3
+    assert sorted(len(c) for c in chunks_seen) == [1, 2, 2]
+    assert sum(len(c) for c in chunks_seen) == 5
+    expected_files = {
+        "F000000000000000000000000000000{}".format(i) for i in range(1, 6)
+    }
+    assert set().union(*chunks_seen) == expected_files


### PR DESCRIPTION
batch_bookmark writes a bookmark after every successful interval in
StatAggregator.run, so a worker killed mid-loop only loses the
interval currently in progress.

incremental switches agg_iter to a two-phase shape: first look up the
field values whose events were touched since the bookmark, then
re-aggregate only those values, chunked by affected_partition_size.
Falls back to the full-interval scan on cold start.

All new flags default to off; existing behavior is preserved.
